### PR TITLE
Align renovate config and GitHub workflows with efffrida

### DIFF
--- a/.github/workflows/lab.yml
+++ b/.github/workflows/lab.yml
@@ -1,0 +1,28 @@
+name: Lab
+
+on:
+  workflow_dispatch:
+
+jobs:
+  lab:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - run: pnpm install
+      - run: pnpm check
+      - run: pnpm lint
+      - run: pnpm circular
+      - run: pnpm build
+
+      - if: ${{ always() }}
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,9 @@ jobs:
           # release branch will not be triggered.
           persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -36,7 +37,7 @@ jobs:
       - run: pnpm install
 
       - name: Upgrade npm for OIDC support
-        run: sudo npm install -g npm@latest
+        run: npm install -g npm@11
 
       - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended", ":dependencyDashboard", "helpers:pinGitHubActionDigests"],
+    "extends": [
+        "mergeConfidence:all-badges",
+        "config:recommended",
+        ":dependencyDashboard",
+        "helpers:pinGitHubActionDigests"
+    ],
     "labels": ["dependencies", "renovate"],
     "ignorePaths": ["**/node_modules/**", "repos/effect/**", "repos/effect-smol/**"],
     "enabledManagers": ["github-actions", "nix", "git-submodules", "pip_requirements", "npm"],
@@ -18,8 +23,65 @@
     },
     "packageRules": [
         {
+            "description": "Group all @types/* packages into one PR",
+            "matchPackageNames": ["/^@types//"],
+            "groupName": "types packages",
+            "addLabels": ["pnpm"]
+        },
+        {
+            "description": "Group all @babel/* packages into one PR",
+            "matchPackageNames": ["/^@babel//", "babel-plugin-annotate-pure-calls"],
+            "groupName": "babel packages",
+            "addLabels": ["pnpm"]
+        },
+        {
+            "description": "Group all @vitest/* packages into one PR",
+            "matchPackageNames": ["/^@vitest//", "vitest", "vite"],
+            "groupName": "vitest packages",
+            "addLabels": ["pnpm"]
+        },
+        {
+            "description": "Group all @changesets/* packages into one PR",
+            "matchPackageNames": ["/^@changesets//"],
+            "groupName": "changesets packages",
+            "addLabels": ["pnpm"]
+        },
+        {
+            "description": "Group all @bufbuild/* packages into one PR",
+            "matchPackageNames": ["/^@bufbuild//"],
+            "groupName": "bufbuild packages",
+            "addLabels": ["pnpm"]
+        },
+        {
+            "description": "Group all Effect-TS packages into one PR",
+            "matchPackageNames": [
+                "effect",
+                "/^@effect//",
+                "!@effect/docgen",
+                "!@effect/build-utils",
+                "!@effect/language-service"
+            ],
+            "groupName": "Effect-TS packages",
+            "addLabels": ["pnpm"]
+        },
+        {
+            "description": "Group build tools packages into one PR",
+            "matchPackageNames": [
+                "oxfmt",
+                "oxlint",
+                "@effect/build-utils",
+                "@effect/docgen",
+                "@effect/language-service",
+                "typescript",
+                "tsx"
+            ],
+            "groupName": "build tools packages",
+            "addLabels": ["pnpm"]
+        },
+        {
+            "description": "Match pnpm's default minimumReleaseAge of 1440 minutes so Renovate never proposes a version pnpm would refuse to install",
             "matchManagers": ["npm"],
-            "enabled": false
+            "minimumReleaseAge": "1 day"
         },
         {
             "description": "Pin GitHub Actions to a full commit SHA and keep that SHA at the latest release",


### PR DESCRIPTION
Brings the Renovate config and CI workflows in line with the conventions used in [efffrida](https://github.com/leonitousconforti/efffrida), adapted where this repo differs.

## renovate.json
- **Re-enables npm dependency updates** — previously `matchManagers: ["npm"], enabled: false`, which is why the dev toolchain (pnpm, oxlint, oxfmt, vitest, etc.) had drifted behind. Replaced with efffrida's rule setting `minimumReleaseAge: "1 day"` to match pnpm's default so Renovate never proposes a version pnpm would refuse to install.
- Adds efffrida's grouping rules so bumps arrive as one PR per cluster: `@types/*`, `@babel/*`, vitest/vite/`@vitest/*`, `@changesets/*`, `@bufbuild/*` (used by tinytower-sdk, insight, and archivist), Effect-TS packages, and build tools (oxlint, oxfmt, typescript, tsx, docgen, build-utils, language-service).
- Adds `mergeConfidence:all-badges` to `extends`.

Note: re-enabling npm updates will trigger a wave of (grouped) Renovate PRs on the next run.

## Workflows
- `main.yml` / `release.yml`: bump `actions/setup-node` v6 → v7 (checkout was already bumped to v7 by Renovate in #34).
- `release.yml`: pin `node-version: 24` (matching main.yml) and swap `sudo npm install -g npm@latest` for `npm install -g npm@11`.
- New `lab.yml`: efffrida's manual `workflow_dispatch` job that runs check/lint/circular/build and then opens a tmate session (`limit-access-to-actor: true`) for interactive CI debugging.

Kept as-is (intentional tinyburg differences): the DigitalOcean deploy jobs in `main.yml`, the `touch ./.env` + `NIMBLEBIT_AUTH_KEY` test setup, and the codegen/docgen drift check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)