### PR TITLE
Copy vscode settings from efffrida

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,13 @@
 {
+    "oxc.useExecPath": true,
+    "oxc.path.oxfmt": "node_modules/oxfmt/bin/oxfmt",
+    "oxc.path.oxlint": "node_modules/oxlint/bin/oxlint",
+
     "js/ts.tsdk.path": "node_modules/typescript/lib",
     "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+    "js/ts.preferences.autoImportFileExcludePatterns": [".direnv/**", "repos/**"],
     "editor.defaultFormatter": "EditorConfig.EditorConfig",
+
     "[typescript][typescriptreact][javascript][javascriptreact][json][jsonc]": {
         "editor.defaultFormatter": "oxc.oxc-vscode"
     },
@@ -10,8 +16,8 @@
     },
 
     "vitest.runtime": "node",
-    "js/ts.preferences.autoImportFileExcludePatterns": [".direnv/**", "repos/**"],
     "vitest.configSearchPatternExclude": "{**/node_modules/**,**/vendor/**,**/repos/**,**/.*/**,**/*.d.ts}",
+
     "files.watcherExclude": {
         ".direnv/**": true,
         "repos/**": true


### PR DESCRIPTION
Syncs `.vscode/settings.json` with [efffrida](https://github.com/leonitousconforti/efffrida)'s — the only real addition is the three `oxc.*` settings pointing the editor extension at the workspace-local oxfmt/oxlint binaries (`oxc.useExecPath` + `oxc.path.oxfmt`/`oxc.path.oxlint`); the rest is just matching key order and spacing. `extensions.json` and `launch.json` were already identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)