### PR TITLE
Allow TypeScript 6 peer dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   '@effect/platform-node-shared': 4.0.0-beta.100
+  '@effect/docgen>typescript': 6.0.3
+  madge>typescript: 6.0.3
 
 importers:
 
@@ -720,7 +722,7 @@ packages:
     hasBin: true
     peerDependencies:
       tsx: ^4.19.3
-      typescript: ^5.8.2
+      typescript: 6.0.3
 
   '@effect/language-service@0.86.2':
     resolution: {integrity: sha512-SaPln+8srOqDJDUwNTDmP5e+IYpEDr9+1epGznnsLqu8xvo6VnxyWARdeLpqvZJlb0Pgy9ca7ppqvvdWbHPXAg==}
@@ -3467,7 +3469,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      typescript: ^5.4.4
+      typescript: 6.0.3
     peerDependenciesMeta:
       typescript:
         optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,12 @@ resolvePeersFromWorkspaceRoot: false
 
 overrides:
   "@effect/platform-node-shared": "4.0.0-beta.100"
+  "@effect/docgen>typescript": "6.0.3"
+  "madge>typescript": "6.0.3"
+
+peerDependencyRules:
+  allowedVersions:
+    typescript: "6.0.3"
 
 allowBuilds:
   '@parcel/watcher': true


### PR DESCRIPTION
Every open Renovate PR is currently failing CI. Renovate cannot regenerate `pnpm-lock.yaml` because full resolution fails under `strictPeerDependencies: true`: `@effect/docgen` (peer `typescript@^5.8.2`) and `madge` (peer `typescript@^5.4.4`) do not accept the repo's TypeScript 6.0.3. Renovate then pushes only the `package.json` change, and CI's frozen-lockfile install fails with `ERR_PNPM_OUTDATED_LOCKFILE`.

This ports the same escape hatch efffrida already uses in its `pnpm-workspace.yaml`:

- `overrides` forcing the `typescript` resolved beneath `@effect/docgen` and `madge` to `6.0.3`
- `peerDependencyRules.allowedVersions` accepting `typescript: 6.0.3` for peer checks

These blocks were missed when #39 aligned the Renovate config and workflows with efffrida. The lockfile is regenerated to record the new overrides; `pnpm install --lockfile-only` now resolves cleanly and the frozen-lockfile check passes.

After merging, the open Renovate PRs need a rebase from the Dependency Dashboard (#31) so Renovate can regenerate their lockfiles.