### PR TITLE
test(nimblebit-sdk): add offline unit tests for auth, config, and schema parsers

### DIFF
--- a/packages/nimblebit-sdk/package.json
+++ b/packages/nimblebit-sdk/package.json
@@ -42,10 +42,14 @@
     "scripts": {
         "build": "tsc -b tsconfig.build.json && babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
         "check": "tsc -b tsconfig.json",
-        "codegen": "build-utils prepare-v4"
+        "codegen": "build-utils prepare-v4",
+        "coverage": "vitest --coverage",
+        "test": "vitest"
     },
     "devDependencies": {
-        "effect": "4.0.0-beta.102"
+        "@effect/vitest": "4.0.0-beta.102",
+        "effect": "4.0.0-beta.102",
+        "vitest": "4.1.10"
     },
     "peerDependencies": {
         "effect": "4.0.0-beta.102"

--- a/packages/nimblebit-sdk/test/NimblebitAuth.test.ts
+++ b/packages/nimblebit-sdk/test/NimblebitAuth.test.ts
@@ -1,0 +1,118 @@
+import { Crypto, Effect, Layer, Redacted } from "effect";
+
+import { describe, expect, it } from "@effect/vitest";
+import { NimblebitAuth, NimblebitConfig } from "@tinyburg/nimblebit-sdk";
+
+const UUID_PATTERN = /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/i;
+
+/** A deterministic {@link Crypto} whose `randomBytes` always returns `bytes`. */
+const testCrypto = (bytes: ReadonlyArray<number>): Layer.Layer<Crypto.Crypto> =>
+    Layer.succeed(
+        Crypto.Crypto,
+        Crypto.make({
+            randomBytes: () => Uint8Array.from(bytes),
+            digest: (_algorithm, data) => Effect.succeed(data),
+        })
+    );
+
+const directAuth = (
+    authKey: string,
+    bytes: ReadonlyArray<number> = [0, 0, 0, 0]
+): Layer.Layer<NimblebitAuth.NimblebitAuth> =>
+    NimblebitAuth.layerDirect(NimblebitConfig.NimblebitAuthKeySchema.make(Redacted.make(authKey))).pipe(
+        Layer.provide(testCrypto(bytes))
+    );
+
+describe("NimblebitAuth.layerDirect", () => {
+    it.effect("targets the official Nimblebit sync host", () =>
+        Effect.gen(function* () {
+            const auth = yield* NimblebitAuth.NimblebitAuth;
+            expect(auth.host).toBe("https://sync.nimblebit.com");
+        }).pipe(Effect.provide(directAuth("test-auth-key")))
+    );
+
+    it.effect("signs data as the md5 of the payload concatenated with the auth key", () =>
+        Effect.gen(function* () {
+            const auth = yield* NimblebitAuth.NimblebitAuth;
+            // md5("save-data" + "test-auth-key")
+            expect(yield* auth.sign("save-data")).toBe("3ea19a2982220d74fbcae3a6244bfad4");
+        }).pipe(Effect.provide(directAuth("test-auth-key")))
+    );
+
+    it.effect("produces a stable signature for the same input", () =>
+        Effect.gen(function* () {
+            const auth = yield* NimblebitAuth.NimblebitAuth;
+            const first = yield* auth.sign("payload");
+            const second = yield* auth.sign("payload");
+            expect(first).toBe(second);
+        }).pipe(Effect.provide(directAuth("test-auth-key")))
+    );
+
+    it.effect("produces different signatures for different auth keys", () =>
+        Effect.gen(function* () {
+            const withKeyA = yield* Effect.provide(
+                Effect.flatMap(NimblebitAuth.NimblebitAuth, (auth) => auth.sign("payload")),
+                directAuth("key-a")
+            );
+            const withKeyB = yield* Effect.provide(
+                Effect.flatMap(NimblebitAuth.NimblebitAuth, (auth) => auth.sign("payload")),
+                directAuth("key-b")
+            );
+            expect(withKeyA).not.toBe(withKeyB);
+        })
+    );
+
+    it.effect("reads the salt as a big-endian uint32 from four random bytes", () =>
+        Effect.gen(function* () {
+            const auth = yield* NimblebitAuth.NimblebitAuth;
+            expect(yield* auth.salt).toBe(1);
+        }).pipe(Effect.provide(directAuth("test-auth-key", [0, 0, 0, 1])))
+    );
+
+    it.effect("reads the maximum salt from all-ones bytes", () =>
+        Effect.gen(function* () {
+            const auth = yield* NimblebitAuth.NimblebitAuth;
+            expect(yield* auth.salt).toBe(4_294_967_295);
+        }).pipe(Effect.provide(directAuth("test-auth-key", [255, 255, 255, 255])))
+    );
+
+    it.effect("hands out a burnbot with a valid player id and auth key", () =>
+        Effect.gen(function* () {
+            const auth = yield* NimblebitAuth.NimblebitAuth;
+            const burnbot = yield* auth.burnbot;
+            expect(["BPQSY", "9GV59", "9GV2Y", "9GTYN"]).toContain(burnbot.playerId);
+            expect(Redacted.value(burnbot.playerAuthKey)).toMatch(UUID_PATTERN);
+        }).pipe(Effect.provide(directAuth("test-auth-key")))
+    );
+
+    it.effect("returns the same burnbot on repeated reads within a layer", () =>
+        Effect.gen(function* () {
+            const auth = yield* NimblebitAuth.NimblebitAuth;
+            const first = yield* auth.burnbot;
+            const second = yield* auth.burnbot;
+            expect(first.playerId).toBe(second.playerId);
+        }).pipe(Effect.provide(directAuth("test-auth-key")))
+    );
+});
+
+describe("NimblebitAuth.layerCustomHost", () => {
+    const customAuth = NimblebitAuth.layerCustomHost({
+        host: "https://authproxy.tinyburg.app",
+        authKey: Redacted.make("proxy-key"),
+    }).pipe(Layer.provide(testCrypto([0, 0, 0, 0])));
+
+    it.effect("targets the configured host", () =>
+        Effect.gen(function* () {
+            const auth = yield* NimblebitAuth.NimblebitAuth;
+            expect(auth.host).toBe("https://authproxy.tinyburg.app");
+        }).pipe(Effect.provide(customAuth))
+    );
+
+    it.effect("signs data by base64url encoding it", () =>
+        Effect.gen(function* () {
+            const auth = yield* NimblebitAuth.NimblebitAuth;
+            // base64url("hello") without padding
+            expect(yield* auth.sign("hello")).toBe("aGVsbG8");
+        }).pipe(Effect.provide(customAuth))
+    );
+});

--- a/packages/nimblebit-sdk/test/NimblebitConfig.test.ts
+++ b/packages/nimblebit-sdk/test/NimblebitConfig.test.ts
@@ -1,0 +1,74 @@
+import { ConfigProvider, Effect, Exit, Redacted, Schema } from "effect";
+
+import { describe, expect, it } from "@effect/vitest";
+import { NimblebitConfig } from "@tinyburg/nimblebit-sdk";
+
+const VALID_AUTH_KEY = "8dad81ae-2626-41b9-8225-325f4809057f";
+
+const withEnv = (env: Record<string, string>) => ConfigProvider.layer(ConfigProvider.fromEnv({ env }));
+
+describe("PlayerIdSchema", () => {
+    it.each(["1", "BPQSY", "ABC12", "ZZZZZ"])("accepts the valid player id %s", (id) => {
+        expect(Schema.decodeUnknownSync(NimblebitConfig.PlayerIdSchema)(id)).toBe(id);
+    });
+
+    it.each([
+        ["empty string", ""],
+        ["lowercase letters", "abcde"],
+        ["more than five characters", "ABCDEF"],
+        ["non-alphanumeric characters", "AB!2"],
+    ])("rejects %s", (_label, id) => {
+        expect(() => Schema.decodeUnknownSync(NimblebitConfig.PlayerIdSchema)(id)).toThrow();
+    });
+});
+
+describe("PlayerAuthKeySchema", () => {
+    it("decodes a redacted UUID into a branded redacted value", () => {
+        const decoded = Schema.decodeUnknownSync(NimblebitConfig.PlayerAuthKeySchema)(Redacted.make(VALID_AUTH_KEY));
+        expect(Redacted.value(decoded)).toBe(VALID_AUTH_KEY);
+    });
+
+    it("rejects a value that is not a UUID", () => {
+        expect(() =>
+            Schema.decodeUnknownSync(NimblebitConfig.PlayerAuthKeySchema)(Redacted.make("not-a-uuid"))
+        ).toThrow();
+    });
+});
+
+describe("PlayerConfig", () => {
+    it.effect("resolves an email-authenticated player", () =>
+        Effect.gen(function* () {
+            const player = yield* NimblebitConfig.PlayerConfig;
+            expect(player.playerId).toBe("AB123");
+            expect("playerEmail" in player).toBe(true);
+            expect("playerAuthKey" in player).toBe(false);
+        }).pipe(Effect.provide(withEnv({ PLAYER_ID: "AB123", PLAYER_EMAIL: "player@example.com" })))
+    );
+
+    it.effect("resolves an auth-key-authenticated player", () =>
+        Effect.gen(function* () {
+            const player = yield* NimblebitConfig.PlayerConfig;
+            expect(player.playerId).toBe("AB123");
+            expect("playerAuthKey" in player).toBe(true);
+            expect("playerEmail" in player).toBe(false);
+        }).pipe(Effect.provide(withEnv({ PLAYER_ID: "AB123", PLAYER_AUTH_KEY: VALID_AUTH_KEY })))
+    );
+
+    it.effect("fails when both an email and an auth key are provided", () =>
+        Effect.gen(function* () {
+            const exit = yield* Effect.exit(NimblebitConfig.PlayerConfig);
+            expect(Exit.isFailure(exit)).toBe(true);
+        }).pipe(
+            Effect.provide(
+                withEnv({ PLAYER_ID: "AB123", PLAYER_EMAIL: "player@example.com", PLAYER_AUTH_KEY: VALID_AUTH_KEY })
+            )
+        )
+    );
+
+    it.effect("fails when neither an email nor an auth key is provided", () =>
+        Effect.gen(function* () {
+            const exit = yield* Effect.exit(NimblebitConfig.PlayerConfig);
+            expect(Exit.isFailure(exit)).toBe(true);
+        }).pipe(Effect.provide(withEnv({ PLAYER_ID: "AB123" })))
+    );
+});

--- a/packages/nimblebit-sdk/test/NimblebitSchema.test.ts
+++ b/packages/nimblebit-sdk/test/NimblebitSchema.test.ts
@@ -1,0 +1,123 @@
+import { Schema } from "effect";
+
+import { describe, expect, it } from "@effect/vitest";
+import { NimblebitSchema } from "@tinyburg/nimblebit-sdk";
+
+const decode = <A, I>(schema: Schema.Codec<A, I>) => Schema.decodeUnknownSync(schema);
+const encode = <A, I>(schema: Schema.Codec<A, I>) => Schema.encodeUnknownSync(schema);
+
+// The number of C# ticks (100ns intervals since 0001-01-01) at the Unix epoch.
+const EPOCH_TICKS = 621_355_968_000_000_000n;
+
+describe("CSharpDate", () => {
+    it("decodes the epoch tick count to the Unix epoch", () => {
+        const decoded = decode(NimblebitSchema.CSharpDate)(EPOCH_TICKS);
+        expect(decoded).toStrictEqual({ date: new Date(0), extraTicks: 0n });
+    });
+
+    it("preserves sub-millisecond ticks in extraTicks", () => {
+        // 12345 ticks past the epoch = 1ms (10000 ticks) + 2345 remainder ticks.
+        const decoded = decode(NimblebitSchema.CSharpDate)(EPOCH_TICKS + 12_345n);
+        expect(decoded).toStrictEqual({ date: new Date(1), extraTicks: 2345n });
+    });
+
+    it("round trips a decoded value back to the original tick count", () => {
+        const ticks = EPOCH_TICKS + 12_345n;
+        const decoded = decode(NimblebitSchema.CSharpDate)(ticks);
+        expect(encode(NimblebitSchema.CSharpDate)(decoded)).toEqual(ticks);
+    });
+
+    it("encodes a plain Date (no extra ticks) to the tick count", () => {
+        expect(encode(NimblebitSchema.CSharpDate)(new Date(0))).toEqual(EPOCH_TICKS);
+    });
+});
+
+describe("UnityColor", () => {
+    it("decodes an r:g:b string into a struct", () => {
+        expect(decode(NimblebitSchema.UnityColor)("255:128:0")).toStrictEqual({ r: 255, g: 128, b: 0 });
+    });
+
+    it("encodes a struct back into an r:g:b string", () => {
+        expect(encode(NimblebitSchema.UnityColor)({ r: 255, g: 128, b: 0 })).toEqual("255:128:0");
+    });
+
+    it("rejects channel values outside the 0-255 range", () => {
+        expect(() => decode(NimblebitSchema.UnityColor)("300:0:0")).toThrow();
+    });
+});
+
+describe("split", () => {
+    const Comma = Schema.String.pipe(NimblebitSchema.split());
+    const Pipe = Schema.String.pipe(NimblebitSchema.split({ separator: "|" }));
+
+    it("splits on a comma by default", () => {
+        expect(decode(Comma)("a,b,c")).toStrictEqual(["a", "b", "c"]);
+    });
+
+    it("joins on a comma when encoding", () => {
+        expect(encode(Comma)(["a", "b"])).toEqual("a,b");
+    });
+
+    it("honours a custom separator", () => {
+        expect(decode(Pipe)("a|b")).toStrictEqual(["a", "b"]);
+        expect(encode(Pipe)(["a", "b"])).toEqual("a|b");
+    });
+});
+
+describe("parseNimblebitObject", () => {
+    const Person = Schema.Struct({
+        name: Schema.String.annotateKey({ nimblebitSaveDataKey: "n" }),
+        level: Schema.NumberFromString.annotateKey({ nimblebitSaveDataKey: "l" }),
+    }).pipe(NimblebitSchema.parseNimblebitObject);
+
+    it("decodes bracketed key/value pairs using the save-data keys", () => {
+        expect(decode(Person)("[n]Alice[n][l]42[l]")).toStrictEqual({
+            name: "Alice",
+            level: 42,
+            $unknown: {},
+        });
+    });
+
+    it("encodes back to the bracketed save-data format", () => {
+        const decoded = decode(Person)("[n]Alice[n][l]42[l]");
+        expect(encode(Person)(decoded)).toEqual("[n]Alice[n][l]42[l]");
+    });
+
+    it("captures unrecognised keys in $unknown with their location", () => {
+        const decoded = decode(Person)("[n]Bob[n][x]hi[x][l]7[l]");
+        expect(decoded).toStrictEqual({
+            name: "Bob",
+            level: 7,
+            $unknown: { x: { value: "hi", $locationMetadata: { after: "name" } } },
+        });
+    });
+
+    it("round trips unknown keys back into their original position", () => {
+        const input = "[n]Bob[n][x]hi[x][l]7[l]";
+        expect(encode(Person)(decode(Person)(input))).toEqual(input);
+    });
+});
+
+describe("parseNimblebitOrderedList", () => {
+    const List = NimblebitSchema.parseNimblebitOrderedList([
+        { property: "a", schema: Schema.String },
+        { property: "b", schema: Schema.String },
+    ]);
+
+    it("assigns the leading items to the declared properties", () => {
+        expect(decode(List)("11,22")).toStrictEqual({ a: "11", b: "22", $unknown: [] });
+    });
+
+    it("collects trailing items into $unknown", () => {
+        expect(decode(List)("123,456,789")).toStrictEqual({ a: "123", b: "456", $unknown: ["789"] });
+    });
+
+    it("round trips including the overflow items", () => {
+        const input = "123,456,789";
+        expect(encode(List)(decode(List)(input))).toEqual(input);
+    });
+
+    it("fails when there are fewer items than declared properties", () => {
+        expect(() => decode(List)("only-one")).toThrow();
+    });
+});

--- a/packages/nimblebit-sdk/tsconfig.json
+++ b/packages/nimblebit-sdk/tsconfig.json
@@ -2,5 +2,5 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "extends": "../../tsconfig.base.jsonc",
     "include": [],
-    "references": [{ "path": "tsconfig.src.json" }]
+    "references": [{ "path": "tsconfig.src.json" }, { "path": "tsconfig.test.json" }]
 }

--- a/packages/nimblebit-sdk/tsconfig.test.json
+++ b/packages/nimblebit-sdk/tsconfig.test.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "../../tsconfig.base.jsonc",
+    "include": ["test/**/*.test.ts"],
+    "references": [{ "path": "tsconfig.src.json" }],
+    "compilerOptions": {
+        "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
+        "outDir": ".tsbuildinfo/test",
+        "noEmit": true,
+        "erasableSyntaxOnly": false,
+        "rewriteRelativeImportExtensions": false,
+        "allowImportingTsExtensions": true,
+        "types": ["node"],
+        "paths": {
+            "@tinyburg/nimblebit-sdk": ["./src/index.ts"],
+            "@tinyburg/nimblebit-sdk/*": ["./src/*/index.ts", "./src/*.ts"]
+        },
+        "plugins": [
+            {
+                "name": "@effect/language-service",
+                "namespaceImportPackages": []
+            }
+        ]
+    }
+}

--- a/packages/nimblebit-sdk/vitest.config.ts
+++ b/packages/nimblebit-sdk/vitest.config.ts
@@ -1,0 +1,7 @@
+import { mergeConfig, type ViteUserConfig } from "vitest/config";
+
+import shared from "../../vitest.shared.ts";
+
+const config: ViteUserConfig = {};
+
+export default mergeConfig(shared, config);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,9 +293,15 @@ importers:
 
   packages/nimblebit-sdk:
     devDependencies:
+      '@effect/vitest':
+        specifier: 4.0.0-beta.102
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)
       effect:
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10
 
   packages/tinytower-sdk:
     dependencies:
@@ -3280,7 +3286,6 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -3907,6 +3912,11 @@ snapshots:
       effect: 4.0.0-beta.102
       vitest: 4.1.10(vite@8.1.5)
 
+  '@effect/vitest@4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)':
+    dependencies:
+      effect: 4.0.0-beta.102
+      vitest: 4.1.10
+
   '@efffrida/frida-tools@0.0.47(effect@4.0.0-beta.102)':
     dependencies:
       effect: 4.0.0-beta.102
@@ -4519,6 +4529,12 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
 
   '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.2)(tsx@4.23.1))':
     dependencies:
@@ -6168,6 +6184,31 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.23.1
 
+  vitest@4.1.10:
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+      - vite
+
   vitest@4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@26.1.2)(tsx@4.23.1)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -6188,13 +6229,13 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@26.1.2)(tsx@4.23.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.2
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
+      - vite
 
   vitest@4.1.10(vite@8.1.5):
     dependencies:
@@ -6216,10 +6257,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.5
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw
+      - vite
 
   walkdir@0.4.1: {}
 


### PR DESCRIPTION
`@tinyburg/nimblebit-sdk` shipped with zero tests and no vitest wiring, even though it holds the SDK's most reused pure logic. This adds an offline unit-test suite (no network, no credentials) covering that logic.

## What's tested
- **NimblebitSchema** (the core save-data parsers used by every game SDK): `CSharpDate` tick conversion + `extraTicks` remainder, `UnityColor` `r:g:b` parsing with range checks, `split`, and both `parseNimblebitObject` / `parseNimblebitOrderedList` including `$unknown` capture and round-trips.
- **NimblebitConfig**: `PlayerIdSchema` / `PlayerAuthKeySchema` validation, and the `PlayerConfig` XOR rule (email-only and auth-key-only resolve; both or neither fail).
- **NimblebitAuth**: `layerDirect` md5 signing, salt decoding as a big-endian uint32 (via a deterministic test `Crypto`), burnbot selection, and `layerCustomHost` base64url signing.

## Wiring
Adds `vitest.config.ts`, `tsconfig.test.json`, the `test` reference, and `test`/`coverage` scripts, mirroring `tinytower-sdk`. Unlike the existing `tinytower-sdk` round-trip test, these need no live Nimblebit connection.

42 tests pass; `pnpm check` and `pnpm lint` are clean.