### PR TITLE
Archive all SDK-supported Nimblebit games in archivist

### DIFF
--- a/apps/archivist/archive.ts
+++ b/apps/archivist/archive.ts
@@ -1,16 +1,24 @@
 import { Effect, Match, Option } from "effect";
 
+import type { BundleIdentifier } from "./games.ts";
+
 import { S3 } from "@effect-aws/client-s3";
 import { NodeStream } from "@effect/platform-node";
 import { GooglePlayApi } from "@efffrida/gplayapi";
 
-const bundleIdentifier = "com.nimblebit.tinytower";
-
-export const archiveToS3 = Effect.fnUntraced(function* (options: { offerType: number; versionCode: number | bigint }) {
-    const streams = yield* GooglePlayApi.downloadToStreams(bundleIdentifier, options).pipe(Effect.catchNoSuchElement);
+export const archiveToS3 = Effect.fnUntraced(function* (options: {
+    bundleIdentifier: BundleIdentifier;
+    offerType: number;
+    versionCode: number | bigint;
+}) {
+    const streams = yield* GooglePlayApi.downloadToStreams(options.bundleIdentifier, options).pipe(
+        Effect.catchNoSuchElement
+    );
 
     if (Option.isNone(streams)) {
-        return yield* Effect.logInfo(`No delivery data available for version ${options.versionCode}`);
+        return yield* Effect.logInfo(
+            `No delivery data available for ${options.bundleIdentifier} version ${options.versionCode}`
+        );
     }
 
     for (const { stream, integrity, size, name } of streams.value) {
@@ -41,7 +49,7 @@ export const archiveToS3 = Effect.fnUntraced(function* (options: { offerType: nu
         const maybeExistingUpload = yield* Effect.flatMap(S3, (s3) =>
             s3.getObject({
                 Bucket: "tinyburg-cold",
-                Key: `archivist/${options?.versionCode}/${name}`,
+                Key: `archivist/${options.bundleIdentifier}/${options.versionCode}/${name}`,
             })
         ).pipe(
             Effect.flatMap(Effect.succeedSome),
@@ -59,11 +67,11 @@ export const archiveToS3 = Effect.fnUntraced(function* (options: { offerType: nu
 
             if (existingUploadIntegrity !== integrityBase64) {
                 yield* Effect.logDebug(
-                    `Integrity check for existing upload ${name} version ${options.versionCode} failed`
+                    `Integrity check for existing upload ${options.bundleIdentifier}/${name} version ${options.versionCode} failed`
                 );
             } else {
                 return yield* Effect.logDebug(
-                    `Integrity check for existing upload ${name} version ${options.versionCode} passed`
+                    `Integrity check for existing upload ${options.bundleIdentifier}/${name} version ${options.versionCode} passed`
                 );
             }
         }
@@ -75,13 +83,15 @@ export const archiveToS3 = Effect.fnUntraced(function* (options: { offerType: nu
                 ContentLength: Number(size),
                 Body: NodeStream.toReadableNever(stream),
                 ChecksumAlgorithm: checksumAlgorithm,
-                Key: `archivist/${options?.versionCode}/${name}`,
+                Key: `archivist/${options.bundleIdentifier}/${options.versionCode}/${name}`,
                 ...("SHA-1" in integrity ? { ChecksumSHA1: integrityBase64 } : {}),
                 ...("SHA-256" in integrity ? { ChecksumSHA256: integrityBase64 } : {}),
                 ...("SHA-512" in integrity ? { ChecksumSHA512: integrityBase64 } : {}),
             })
         );
 
-        yield* Effect.logDebug(`Successfully uploaded ${name} version ${options.versionCode} to S3`);
+        yield* Effect.logDebug(
+            `Successfully uploaded ${options.bundleIdentifier}/${name} version ${options.versionCode} to S3`
+        );
     }
 });

--- a/apps/archivist/games.ts
+++ b/apps/archivist/games.ts
@@ -1,0 +1,11 @@
+// Nimblebit games we want to support with sdks. Tiny Tower Classic is
+// iOS-only (no Google Play listing), so it cannot be archived from here.
+export const bundleIdentifiers = [
+    "com.nimblebit.tinytower", // tinytower-sdk
+    "com.nimblebit.vegas", // tinytower-vegas-sdk
+    "com.nimblebit.pocketplanes", // pocket-planes-sdk
+    "com.nimblebit.pockettrains", // pocket-trains-sdk
+    "com.nimblebit.pockettrucks", // pocket-trucks-sdk
+] as const;
+
+export type BundleIdentifier = (typeof bundleIdentifiers)[number];

--- a/apps/archivist/index.ts
+++ b/apps/archivist/index.ts
@@ -4,12 +4,14 @@ import { NodeRuntime } from "@effect/platform-node";
 import { GooglePlayApi } from "@efffrida/gplayapi";
 
 import { archiveToS3 } from "./archive.ts";
+import { bundleIdentifiers } from "./games.ts";
 import { Live } from "./layers.ts";
 
 Effect.gen(function* () {
-    const bundleIdentifier = "com.nimblebit.tinytower";
-    const details = yield* GooglePlayApi.details(bundleIdentifier);
-    const versionCode = details.item?.details?.appDetails?.versionCode ?? 0n;
-    yield* Effect.logInfo(`Archiving ${bundleIdentifier} version ${versionCode}`);
-    yield* archiveToS3({ offerType: details.item?.offer[0].offerType ?? 1, versionCode });
+    for (const bundleIdentifier of bundleIdentifiers) {
+        const details = yield* GooglePlayApi.details(bundleIdentifier);
+        const versionCode = details.item?.details?.appDetails?.versionCode ?? 0n;
+        yield* Effect.logInfo(`Archiving ${bundleIdentifier} version ${versionCode}`);
+        yield* archiveToS3({ bundleIdentifier, offerType: details.item?.offer[0].offerType ?? 1, versionCode });
+    }
 }).pipe(Effect.provide(Live), NodeRuntime.runMain);

--- a/apps/archivist/seed.ts
+++ b/apps/archivist/seed.ts
@@ -4,14 +4,16 @@ import { NodeRuntime } from "@effect/platform-node";
 import { GooglePlayApi } from "@efffrida/gplayapi";
 
 import { archiveToS3 } from "./archive.ts";
+import { bundleIdentifiers } from "./games.ts";
 import { Live } from "./layers.ts";
 
 Effect.gen(function* () {
-    const bundleIdentifier = "com.nimblebit.tinytower";
-    const { item } = yield* GooglePlayApi.details(bundleIdentifier);
-    const maxVersionCode = item?.details?.appDetails?.versionCode ?? 0n;
-    for (let versionCode = BigInt(0); versionCode <= maxVersionCode; versionCode++) {
-        yield* Effect.logInfo(`Archiving ${bundleIdentifier} version ${versionCode}`);
-        yield* archiveToS3({ offerType: item?.offer[0].offerType ?? 1, versionCode });
+    for (const bundleIdentifier of bundleIdentifiers) {
+        const { item } = yield* GooglePlayApi.details(bundleIdentifier);
+        const maxVersionCode = item?.details?.appDetails?.versionCode ?? 0n;
+        for (let versionCode = BigInt(0); versionCode <= maxVersionCode; versionCode++) {
+            yield* Effect.logInfo(`Archiving ${bundleIdentifier} version ${versionCode}`);
+            yield* archiveToS3({ bundleIdentifier, offerType: item?.offer[0].offerType ?? 1, versionCode });
+        }
     }
 }).pipe(Effect.provide(Live), NodeRuntime.runMain);


### PR DESCRIPTION
Archivist was hardcoded to Tiny Tower. It now archives every Nimblebit game we have an SDK package for.

- New `apps/archivist/games.ts` lists the bundle identifiers: tinytower, vegas, pocketplanes, pockettrains, pockettrucks (all verified against NimbleBit's Play Store developer page)
- `archiveToS3` takes the bundle identifier as an option and includes it in log lines
- `index.ts` archives the latest version of each game; `seed.ts` backfills all version codes per game
- S3 keys are now namespaced per game: `archivist/<bundleId>/<versionCode>/<name>`. Existing Tiny Tower objects live under the old un-namespaced prefix and would be re-uploaded on the next seed run unless copied over first

Note: Tiny Tower Classic has no Google Play listing (iOS-only), so it cannot be archived through the Google Play API.