### PR TITLE
Only exclude template-generated index.ts files from oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -7,10 +7,15 @@
         "**/.tsbuildinfo",
         "**/generated/**",
         ".agents/**/*",
-        "**/index.ts",
         "repos/**",
         "**/CHANGELOG.md",
-        "!apps/**/index.ts"
+        // These index.ts files are generated from index.ts.tpl templates, so formatting them
+        // would drift from the generator's output.
+        "packages/bitprints/src/index.ts",
+        "packages/doorman/src/index.ts",
+        "packages/nimblebit-sdk/src/index.ts",
+        "packages/tinytower-sdk/src/index.ts",
+        "packages/trading-sdk/src/index.ts"
     ],
     "sortPackageJson": true,
     "trailingComma": "es5",


### PR DESCRIPTION
Previously .oxfmtrc.json ignored every index.ts outside apps/, so "format document" silently no-oped on hand-written barrel files like packages/insight/src/node/index.ts and packages/ui/src/index.ts.

Now only the five index.ts files generated from an index.ts.tpl template (bitprints, doorman, nimblebit-sdk, tinytower-sdk, trading-sdk) stay excluded, since reformatting those would drift from the generator's output. Everything else is formattable.

Both newly included files already pass oxfmt --check, so no reformatting was needed.