### PR TITLE
Update effect-oidc to 0.0.9

### DIFF
--- a/apps/authproxy/package.json
+++ b/apps/authproxy/package.json
@@ -17,7 +17,7 @@
         "@tinyburg/tinytower-sdk": "workspace:*",
         "@tinyburg/ui": "workspace:*",
         "effect": "4.0.0-beta.105",
-        "effect-oidc": "0.0.8",
+        "effect-oidc": "0.0.9",
         "foldkit": "0.140.1",
         "ioredis": "5.11.1",
         "tailwindcss": "4.3.3",

--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -11,7 +11,7 @@
         "@effect/sql-pg": "4.0.0-beta.105",
         "dfx": "1.0.15",
         "effect": "4.0.0-beta.105",
-        "effect-oidc": "0.0.8",
+        "effect-oidc": "0.0.9",
         "ioredis": "5.11.1",
         "typescript": "7.0.2"
     }

--- a/apps/social-circles/package.json
+++ b/apps/social-circles/package.json
@@ -19,7 +19,7 @@
         "@tinyburg/tinytower-sdk": "workspace:*",
         "@tinyburg/trading-sdk": "workspace:*",
         "effect": "4.0.0-beta.105",
-        "effect-oidc": "0.0.8",
+        "effect-oidc": "0.0.9",
         "foldkit": "0.140.1",
         "ioredis": "5.11.1",
         "tailwindcss": "4.3.3",

--- a/apps/tinyburg.app/package.json
+++ b/apps/tinyburg.app/package.json
@@ -20,7 +20,7 @@
         "@tinyburg/trading-sdk": "workspace:^",
         "@tinyburg/ui": "workspace:*",
         "effect": "4.0.0-beta.105",
-        "effect-oidc": "0.0.8",
+        "effect-oidc": "0.0.9",
         "foldkit": "0.140.1",
         "ioredis": "5.11.1",
         "tailwindcss": "4.3.3",

--- a/packages/trading-sdk/package.json
+++ b/packages/trading-sdk/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@tinyburg/nimblebit-sdk": "workspace:^",
-        "effect-oidc": "0.0.8"
+        "effect-oidc": "0.0.9"
     },
     "devDependencies": {
         "effect": "4.0.0-beta.105"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: 4.0.0-beta.105
         version: 4.0.0-beta.105
       effect-oidc:
-        specifier: 0.0.8
-        version: 0.0.8(effect@4.0.0-beta.105)
+        specifier: 0.0.9
+        version: 0.0.9(effect@4.0.0-beta.105)
       foldkit:
         specifier: 0.140.1
         version: 0.140.1(@effect/platform-browser@4.0.0-beta.105(effect@4.0.0-beta.105))(effect@4.0.0-beta.105)
@@ -187,8 +187,8 @@ importers:
         specifier: 4.0.0-beta.105
         version: 4.0.0-beta.105
       effect-oidc:
-        specifier: 0.0.8
-        version: 0.0.8(effect@4.0.0-beta.105)
+        specifier: 0.0.9
+        version: 0.0.9(effect@4.0.0-beta.105)
       ioredis:
         specifier: 5.11.1
         version: 5.11.1
@@ -262,8 +262,8 @@ importers:
         specifier: 4.0.0-beta.105
         version: 4.0.0-beta.105
       effect-oidc:
-        specifier: 0.0.8
-        version: 0.0.8(effect@4.0.0-beta.105)
+        specifier: 0.0.9
+        version: 0.0.9(effect@4.0.0-beta.105)
       foldkit:
         specifier: 0.140.1
         version: 0.140.1(@effect/platform-browser@4.0.0-beta.105(effect@4.0.0-beta.105))(effect@4.0.0-beta.105)
@@ -319,8 +319,8 @@ importers:
         specifier: 4.0.0-beta.105
         version: 4.0.0-beta.105
       effect-oidc:
-        specifier: 0.0.8
-        version: 0.0.8(effect@4.0.0-beta.105)
+        specifier: 0.0.9
+        version: 0.0.9(effect@4.0.0-beta.105)
       foldkit:
         specifier: 0.140.1
         version: 0.140.1(@effect/platform-browser@4.0.0-beta.105(effect@4.0.0-beta.105))(effect@4.0.0-beta.105)
@@ -430,8 +430,8 @@ importers:
         specifier: workspace:^
         version: link:../nimblebit-sdk
       effect-oidc:
-        specifier: 0.0.8
-        version: 0.0.8(effect@4.0.0-beta.105)
+        specifier: 0.0.9
+        version: 0.0.9(effect@4.0.0-beta.105)
     devDependencies:
       effect:
         specifier: 4.0.0-beta.105
@@ -2185,11 +2185,11 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
-  effect-oidc@0.0.8:
-    resolution: {integrity: sha512-RPdQlJGdLsyLUKHNFVZDwXagmvNxMG/ZLvMNdiNin4ErSx5d5oS2+xcZtkRea1cu9wP6907GR5iYaRuaH1gJpg==}
+  effect-oidc@0.0.9:
+    resolution: {integrity: sha512-EVish6t9ILvCz6TIq3Px/In0GZYpM1J7WVN9dWR5ir5BXfG4BVj57E7rs+MNbXabIfdwjBPdIumnXIAK6H6KFw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      effect: 4.0.0-beta.104
+      effect: 4.0.0-beta.105
 
   effect@4.0.0-beta.105:
     resolution: {integrity: sha512-7U5OzWVNlpnZFvXiZfOeu8V+dCQUa3Om569HnYG2Dx8C8V6uoKS920kFJkIDEYVhlSGhzkRqaGKmYY9bPkBMMQ==}
@@ -5246,7 +5246,7 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  effect-oidc@0.0.8(effect@4.0.0-beta.105):
+  effect-oidc@0.0.9(effect@4.0.0-beta.105):
     dependencies:
       effect: 4.0.0-beta.105
 


### PR DESCRIPTION
Bumps the five effect-oidc pins from 0.0.8 to 0.0.9, which moved its effect peer pin from 4.0.0-beta.104 to 4.0.0-beta.105 (effect-oidc#37). With the pin matching the monorepo's effect version, fresh lockfile resolutions no longer fail under strictPeerDependencies.

Based on main so it can merge first, ahead of #93/#94/#95. No code changes; 0.0.8 and 0.0.9 are API-identical, and the repo typecheck passes against 0.0.9 on main's code. #95 will need a small lockfile rebase once this lands.