### PR TITLE
Sort named import specifiers

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -49,6 +49,12 @@
             }
         ],
         "typescript/no-import-type-side-effects": "error",
+        "eslint/sort-imports": [
+            "error",
+            {
+                "ignoreDeclarationSort": true
+            }
+        ],
         "import/no-duplicates": "error",
         "import/no-self-import": "error",
         "import/no-empty-named-blocks": "error",

--- a/apps/archivist/layers.ts
+++ b/apps/archivist/layers.ts
@@ -1,4 +1,4 @@
-import { Config, Effect, Layer, References, Redacted, ConfigProvider } from "effect";
+import { Config, ConfigProvider, Effect, Layer, Redacted, References } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 
 import { S3 } from "@effect-aws/client-s3";

--- a/apps/authproxy/client/entry.ts
+++ b/apps/authproxy/client/entry.ts
@@ -3,7 +3,7 @@ import "./styles/global.css";
 import { Runtime } from "foldkit";
 
 import { BackendLive } from "./backend.ts";
-import { ChangedUrl, ClickedLink, init, Model, update, view } from "./main.ts";
+import { ChangedUrl, ClickedLink, Model, init, update, view } from "./main.ts";
 
 const application = Runtime.makeApplication({
     Model,

--- a/apps/authproxy/client/main.ts
+++ b/apps/authproxy/client/main.ts
@@ -10,14 +10,14 @@ import { type Backend, CheckingSession, FetchSession, GotSession, SessionState, 
 import {
     AdminMessage,
     AdminModel,
+    FetchAdminKeys,
     adminView,
     enterAdmin,
-    FetchAdminKeys,
     initialAdmin,
     updateAdmin,
 } from "./pages/admin.ts";
 import { homeView } from "./pages/home.ts";
-import { enterKeys, FetchKeys, initialKeys, KeysMessage, KeysModel, keysView, updateKeys } from "./pages/keys.ts";
+import { FetchKeys, KeysMessage, KeysModel, enterKeys, initialKeys, keysView, updateKeys } from "./pages/keys.ts";
 import { loginView } from "./pages/login.ts";
 import { notFoundView } from "./pages/notFound.ts";
 import { AppRoute, loginHref, urlToAppRoute } from "./routes.ts";

--- a/apps/authproxy/client/routes.ts
+++ b/apps/authproxy/client/routes.ts
@@ -1,4 +1,4 @@
-import { Option, pipe, Schema as S } from "effect";
+import { Option, Schema as S, pipe } from "effect";
 
 import { Route } from "foldkit";
 import { literal, r } from "foldkit/route";

--- a/apps/authproxy/domain/model.ts
+++ b/apps/authproxy/domain/model.ts
@@ -1,6 +1,6 @@
-import { Context, Effect, Schema, Layer, SchemaGetter } from "effect";
+import { Context, Effect, Layer, Schema, SchemaGetter } from "effect";
 import { Model } from "effect/unstable/schema";
-import { SqlClient, SqlSchema, SqlModel } from "effect/unstable/sql";
+import { SqlClient, SqlModel, SqlSchema } from "effect/unstable/sql";
 
 /**
  * The current account in context, provided by middleware.

--- a/apps/authproxy/index.ts
+++ b/apps/authproxy/index.ts
@@ -1,4 +1,4 @@
-import { Config, Effect, Layer, String, Path } from "effect";
+import { Config, Effect, Layer, Path, String } from "effect";
 import { FetchHttpClient, HttpRouter } from "effect/unstable/http";
 import { RateLimiter } from "effect/unstable/persistence";
 

--- a/apps/authproxy/middleware/10_authorization.ts
+++ b/apps/authproxy/middleware/10_authorization.ts
@@ -1,11 +1,11 @@
 import type { SqlError } from "effect/unstable/sql";
 
-import { Effect, Option, Layer, Redacted, Array, DateTime, Duration, Schema } from "effect";
+import { Array, DateTime, Duration, Effect, Layer, Option, Redacted, Schema } from "effect";
 import { Headers, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
-import { HttpApiMiddleware, HttpApiSecurity, HttpApiError } from "effect/unstable/httpapi";
+import { HttpApiError, HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi";
 import { RateLimiter } from "effect/unstable/persistence";
 
-import { type CurrentAccount, Repository, Account } from "../domain/model.ts";
+import { Account, type CurrentAccount, Repository } from "../domain/model.ts";
 
 export class Authorization extends HttpApiMiddleware.Service<
     Authorization,

--- a/apps/authproxy/middleware/20_tinytowerDecode.ts
+++ b/apps/authproxy/middleware/20_tinytowerDecode.ts
@@ -1,4 +1,4 @@
-import { Effect, Option, Schema, String, Layer } from "effect";
+import { Effect, Layer, Option, Schema, String } from "effect";
 import { HttpRouter, HttpServerRequest } from "effect/unstable/http";
 import { HttpApiError, HttpApiMiddleware } from "effect/unstable/httpapi";
 

--- a/apps/authproxy/routes/accounts.ts
+++ b/apps/authproxy/routes/accounts.ts
@@ -1,4 +1,4 @@
-import { Config, Effect, Layer, Option, Redacted, Schema, Function } from "effect";
+import { Config, Effect, Function, Layer, Option, Redacted, Schema } from "effect";
 import {
     HttpApi,
     HttpApiBuilder,

--- a/apps/authproxy/routes/health.ts
+++ b/apps/authproxy/routes/health.ts
@@ -1,5 +1,5 @@
 import { Duration, Effect, Layer } from "effect";
-import { HttpRouter, HttpServerResponse, HttpClient } from "effect/unstable/http";
+import { HttpClient, HttpRouter, HttpServerResponse } from "effect/unstable/http";
 
 import { NimblebitAuth } from "@tinyburg/nimblebit-sdk";
 import { TinyTower } from "@tinyburg/tinytower-sdk";

--- a/apps/authproxy/routes/oauth.ts
+++ b/apps/authproxy/routes/oauth.ts
@@ -16,7 +16,7 @@ import type { Jwt } from "effect-oidc";
 
 import { Oidc } from "effect-oidc";
 
-import { CookiePolicy, maybeCurrentSession, SESSION_COOKIE_NAME } from "../cookies.ts";
+import { CookiePolicy, SESSION_COOKIE_NAME, maybeCurrentSession } from "../cookies.ts";
 import { randomSecret, sha256 } from "../crypto.ts";
 import { SessionsRepository } from "../domain/sessions.ts";
 // "Sign in with Tinyburg": the authproxy is an OIDC relying party of

--- a/apps/social-circles/client/entry.ts
+++ b/apps/social-circles/client/entry.ts
@@ -3,7 +3,7 @@ import "./styles/global.css";
 import { Runtime } from "foldkit";
 
 import { BackendLive } from "./backend.ts";
-import { ChangedUrl, ClickedLink, init, Model, update, view } from "./main.ts";
+import { ChangedUrl, ClickedLink, Model, init, update, view } from "./main.ts";
 
 const application = Runtime.makeApplication({
     Model,

--- a/apps/social-circles/client/main.ts
+++ b/apps/social-circles/client/main.ts
@@ -12,11 +12,11 @@ import { loginView } from "./pages/login.ts";
 import { notFoundView } from "./pages/notFound.ts";
 import { privacyView } from "./pages/privacy.ts";
 import {
-    enterTowers,
     FetchTowers,
-    initialTowers,
     TowersMessage,
     TowersModel,
+    enterTowers,
+    initialTowers,
     towersView,
     updateTowers,
 } from "./pages/towers.ts";

--- a/apps/social-circles/client/pages/towers.ts
+++ b/apps/social-circles/client/pages/towers.ts
@@ -1,4 +1,4 @@
-import { DateTime, Match, Option, Result, Schema as S, Effect } from "effect";
+import { DateTime, Effect, Match, Option, Result, Schema as S } from "effect";
 
 import type { Message as AppMessage } from "../main.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";

--- a/apps/social-circles/client/routes.ts
+++ b/apps/social-circles/client/routes.ts
@@ -1,4 +1,4 @@
-import { Option, pipe, Schema as S } from "effect";
+import { Option, Schema as S, pipe } from "effect";
 
 import { Route } from "foldkit";
 import { literal, r } from "foldkit/route";

--- a/apps/social-circles/domain/graph.ts
+++ b/apps/social-circles/domain/graph.ts
@@ -13,7 +13,7 @@
 
 import type { SqlError } from "effect/unstable/sql";
 
-import { Array, Effect, Context, Layer, Schema, pipe } from "effect";
+import { Array, Context, Effect, Layer, Schema, pipe } from "effect";
 import { SqlClient, SqlSchema } from "effect/unstable/sql";
 
 import type { PlayerId } from "./model.ts";

--- a/apps/social-circles/domain/purge.ts
+++ b/apps/social-circles/domain/purge.ts
@@ -11,7 +11,7 @@ import type { SqlError } from "effect/unstable/sql";
 import { Context, Effect, Layer, Schema } from "effect";
 import { SqlClient, SqlSchema } from "effect/unstable/sql";
 
-import { PurgeReceipt, type PlayerId } from "./model.ts";
+import { type PlayerId, PurgeReceipt } from "./model.ts";
 
 export class PurgeRepository extends Context.Service<PurgeRepository>()(
     "@tinyburg/social-circles/domain/PurgeRepository",

--- a/apps/social-circles/routes/oauth.ts
+++ b/apps/social-circles/routes/oauth.ts
@@ -21,7 +21,7 @@ import type { Jwt } from "effect-oidc";
 
 import { Oidc } from "effect-oidc";
 
-import { CookiePolicy, maybeCurrentSession, SESSION_COOKIE_NAME } from "../cookies.ts";
+import { CookiePolicy, SESSION_COOKIE_NAME, maybeCurrentSession } from "../cookies.ts";
 import { randomSecret, seal, sha256 } from "../crypto.ts";
 import { GrantsRepository } from "../domain/grants.ts";
 import { SessionsRepository } from "../domain/sessions.ts";

--- a/apps/tinyburg.app/client/entry.ts
+++ b/apps/tinyburg.app/client/entry.ts
@@ -3,7 +3,7 @@ import "./styles/global.css";
 import { Runtime } from "foldkit";
 
 import { BackendLive } from "./backend.ts";
-import { ChangedUrl, ClickedLink, init, Model, update, view, viewTransition } from "./main.ts";
+import { ChangedUrl, ClickedLink, Model, init, update, view, viewTransition } from "./main.ts";
 
 const application = Runtime.makeApplication({
     Model,

--- a/apps/tinyburg.app/client/main.ts
+++ b/apps/tinyburg.app/client/main.ts
@@ -22,10 +22,10 @@ import { aboutView } from "./pages/about.ts";
 import {
     AccountMessage,
     AccountModel,
-    accountView,
-    enterAccount,
     FetchLinkedAccounts,
     FetchSessions,
+    accountView,
+    enterAccount,
     initialAccount,
     updateAccount,
 } from "./pages/account.ts";
@@ -37,7 +37,7 @@ import { notFoundView } from "./pages/notFound.ts";
 import { privacyView } from "./pages/privacy.ts";
 import { sponsorsView } from "./pages/sponsors.ts";
 import { termsView } from "./pages/terms.ts";
-import { initialWizard, towerLinkView, updateWizard, WizardMessage, WizardModel } from "./pages/towerLink.ts";
+import { WizardMessage, WizardModel, initialWizard, towerLinkView, updateWizard } from "./pages/towerLink.ts";
 import { towerMeView } from "./pages/towerMe.ts";
 import { AppRoute, loginHref, urlToAppRoute } from "./routes.ts";
 import { clouds } from "./ui/chrome.ts";

--- a/apps/tinyburg.app/client/routes.ts
+++ b/apps/tinyburg.app/client/routes.ts
@@ -1,4 +1,4 @@
-import { Option, pipe, Schema as S } from "effect";
+import { Option, Schema as S, pipe } from "effect";
 
 import { Route } from "foldkit";
 import { literal, r, slash } from "foldkit/route";

--- a/apps/tinyburg.app/domain/developers.ts
+++ b/apps/tinyburg.app/domain/developers.ts
@@ -1,7 +1,7 @@
 import type { SqlError } from "effect/unstable/sql";
 
 import { Context, Effect, Function, Layer, Schema } from "effect";
-import { SqlClient, SqlSchema, SqlModel } from "effect/unstable/sql";
+import { SqlClient, SqlModel, SqlSchema } from "effect/unstable/sql";
 
 import { OAuthClient } from "./models.ts";
 

--- a/apps/tinyburg.app/domain/oidc.ts
+++ b/apps/tinyburg.app/domain/oidc.ts
@@ -1,7 +1,7 @@
 import type { SqlError } from "effect/unstable/sql";
 
 import { Context, Effect, Layer, Schedule, Schema } from "effect";
-import { SqlClient, SqlSchema, SqlModel } from "effect/unstable/sql";
+import { SqlClient, SqlModel, SqlSchema } from "effect/unstable/sql";
 
 import { OAuthAuthorizationRequest, RefreshToken } from "./models.ts";
 

--- a/apps/tinyburg.app/domain/users.ts
+++ b/apps/tinyburg.app/domain/users.ts
@@ -1,7 +1,7 @@
 import type { SqlError } from "effect/unstable/sql";
 
 import { Context, Effect, Function, Layer, Schema } from "effect";
-import { SqlClient, SqlSchema, SqlModel } from "effect/unstable/sql";
+import { SqlClient, SqlModel, SqlSchema } from "effect/unstable/sql";
 
 import { OAuthAccount, User } from "./models.ts";
 

--- a/apps/tinyburg.app/server/routes/api.ts
+++ b/apps/tinyburg.app/server/routes/api.ts
@@ -5,7 +5,7 @@ import { Model } from "effect/unstable/schema";
 
 import type { Session, User } from "../../domain/models.ts";
 
-import { Oidc, ResourceServer, Jwt } from "effect-oidc";
+import { Jwt, Oidc, ResourceServer } from "effect-oidc";
 
 import { DevelopersRepository } from "../../domain/developers.ts";
 import { OidcRepository } from "../../domain/oidc.ts";

--- a/apps/tinyburg.app/server/routes/auth.ts
+++ b/apps/tinyburg.app/server/routes/auth.ts
@@ -5,7 +5,7 @@ import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi";
 import { SessionsRepository } from "../../domain/sessions.ts";
 import { UsersRepository } from "../../domain/users.ts";
 import { AuthApi, CurrentSession, SessionCookie } from "../../shared/auth.ts";
-import { CookiePolicy, maybeCurrentUser, PROVIDER_SESSION_COOKIE_NAME } from "../cookies.ts";
+import { CookiePolicy, PROVIDER_SESSION_COOKIE_NAME, maybeCurrentUser } from "../cookies.ts";
 
 const SessionCookieLive = Layer.effect(
     SessionCookie,

--- a/apps/tinyburg.app/server/routes/oauth.ts
+++ b/apps/tinyburg.app/server/routes/oauth.ts
@@ -17,7 +17,7 @@ import { type Jwt, Oidc } from "effect-oidc";
 
 import { SessionsRepository } from "../../domain/sessions.ts";
 import { UsersRepository } from "../../domain/users.ts";
-import { CookiePolicy, maybeCurrentUser, PROVIDER_SESSION_COOKIE_NAME } from "../cookies.ts";
+import { CookiePolicy, PROVIDER_SESSION_COOKIE_NAME, maybeCurrentUser } from "../cookies.ts";
 import { randomSecret, sha256 } from "../crypto.ts";
 
 interface OAuthProvider {

--- a/apps/tinyburg.app/test/pages/account.test.ts
+++ b/apps/tinyburg.app/test/pages/account.test.ts
@@ -9,22 +9,22 @@ import { Scene } from "foldkit/test";
 import { describe, it } from "vitest";
 
 import {
-    type AccountModel,
     AccountMessage,
-    accountView,
+    type AccountModel,
     CompletedRevoke,
     CompletedUnlink,
-    enterAccount,
     FailedAction,
     FetchLinkedAccounts,
     FetchSessions,
-    initialAccount,
     RevokeAll,
     RevokeOthers,
     RevokeSession,
     SettledLinkedAccounts,
     SettledSessions,
     Unlink,
+    accountView,
+    enterAccount,
+    initialAccount,
     updateAccount,
 } from "../../client/pages/account.ts";
 

--- a/packages/insight/src/frida/Agent.ts
+++ b/packages/insight/src/frida/Agent.ts
@@ -1,7 +1,7 @@
 import "@efffrida/polyfills";
 import "frida-il2cpp-bridge";
 
-import { Array, Cause, Effect, Function, Layer, Option, pipe, Record, Schedule, Schema, Tuple, Result } from "effect";
+import { Array, Cause, Effect, Function, Layer, Option, Record, Result, Schedule, Schema, Tuple, pipe } from "effect";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 
 import { Assembly, Class, Extensions, FridaIl2cppBridge } from "@efffrida/il2cpp-bridge";

--- a/packages/insight/src/node/index.ts
+++ b/packages/insight/src/node/index.ts
@@ -1,33 +1,33 @@
 import type { HttpClient, HttpClientError } from "effect/unstable/http";
 
 import {
-    Effect,
-    Layer,
-    Stream,
-    type Path,
-    type Config,
     type Cause,
-    type Exit,
-    type Crypto,
-    type Schema,
-    type PlatformError,
-    type FileSystem,
-    Tuple,
-    Duration,
+    type Config,
     Context,
+    type Crypto,
+    Duration,
+    Effect,
+    type Exit,
+    type FileSystem,
+    Layer,
+    type Path,
+    type PlatformError,
+    type Schema,
+    Stream,
     String,
+    Tuple,
 } from "effect";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
-import { RpcSerialization, type RpcClient } from "effect/unstable/rpc";
+import { type RpcClient, RpcSerialization } from "effect/unstable/rpc";
 
 import {
-    FridaScript,
-    FridaSession,
     FridaDevice,
     FridaDeviceAcquisitionError,
+    FridaScript,
+    FridaSession,
     type FridaSessionError,
 } from "@efffrida/frida-tools";
-import { GooglePlayApi, type AndroidDevice, type PlayAccount } from "@efffrida/gplayapi";
+import { type AndroidDevice, GooglePlayApi, type PlayAccount } from "@efffrida/gplayapi";
 import { FridaRpcClient } from "@efffrida/rpc/node";
 import { JsPlatform } from "frida";
 

--- a/packages/tinytower-sdk/scripts/GenerateData.ts
+++ b/packages/tinytower-sdk/scripts/GenerateData.ts
@@ -1,8 +1,8 @@
-import { Array, Effect, Layer, Order, pipe, Record, FileSystem, Path } from "effect";
+import { Array, Effect, FileSystem, Layer, Order, Path, Record, pipe } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import { RpcClient } from "effect/unstable/rpc";
 
-import { NodeServices, NodeRuntime } from "@effect/platform-node";
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
 import { AndroidDevice, GooglePlayApi, PlayAccount } from "@efffrida/gplayapi";
 import { AgentLive, DeviceLive } from "@tinyburg/insight/node/index";
 import { Rpcs } from "@tinyburg/insight/shared/Rpcs";

--- a/packages/tinytower-sdk/test/schema.test.ts
+++ b/packages/tinytower-sdk/test/schema.test.ts
@@ -1,4 +1,4 @@
-import { ManagedRuntime, ConfigProvider, Effect, Layer, Path, Schema } from "effect";
+import { ConfigProvider, Effect, Layer, ManagedRuntime, Path, Schema } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 
 import { NodeServices } from "@effect/platform-node";

--- a/packages/tinytower-sdk/vitest.config.ts
+++ b/packages/tinytower-sdk/vitest.config.ts
@@ -1,4 +1,4 @@
-import { mergeConfig, type ViteUserConfig } from "vitest/config";
+import { type ViteUserConfig, mergeConfig } from "vitest/config";
 
 import shared from "../../vitest.shared.ts";
 


### PR DESCRIPTION
Enables `eslint/sort-imports` with `ignoreDeclarationSort: true` in `.oxlintrc.json`, so oxlint enforces (and autofixes) alphabetical order of the names inside import braces without touching the order of the import statements themselves. Type and value specifiers interleave, sorted by name.

The rest of the diff is the one-time `pnpm lint-fix` pass sorting existing imports.