### PR TITLE
Add shared internationalization helpers to @tinyburg/ui

### DIFF
--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -9,6 +9,7 @@
     "dependencies": {
         "@effect/platform-node": "4.0.0-beta.105",
         "@effect/sql-pg": "4.0.0-beta.105",
+        "@tinyburg/ui": "workspace:*",
         "dfx": "1.0.15",
         "effect": "4.0.0-beta.105",
         "effect-oidc": "0.0.9",

--- a/apps/discord-bot/tsconfig.json
+++ b/apps/discord-bot/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "extends": "../../tsconfig.base.jsonc",
-    "references": [],
+    "references": [{ "path": "../../packages/ui/tsconfig.src.json" }],
     "include": ["domain", "migrations", "routes", "crypto.ts", "index.ts", "interactions.ts", "tinyburg.ts"],
     "compilerOptions": {
         "noEmit": true,

--- a/apps/social-circles/package.json
+++ b/apps/social-circles/package.json
@@ -18,6 +18,7 @@
         "@tinyburg/nimblebit-sdk": "workspace:*",
         "@tinyburg/tinytower-sdk": "workspace:*",
         "@tinyburg/trading-sdk": "workspace:*",
+        "@tinyburg/ui": "workspace:*",
         "effect": "4.0.0-beta.105",
         "effect-oidc": "0.0.9",
         "foldkit": "0.140.1",

--- a/apps/social-circles/tsconfig.json
+++ b/apps/social-circles/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../tsconfig.base.jsonc",
     "references": [
+        { "path": "../../packages/ui/tsconfig.src.json" },
         { "path": "../../packages/nimblebit-sdk/tsconfig.src.json" },
         { "path": "../../packages/tinytower-sdk/tsconfig.src.json" },
         { "path": "../../packages/trading-sdk/tsconfig.src.json" }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,5 +34,13 @@
         "@effect/platform-browser": "4.0.0-beta.105",
         "effect": "4.0.0-beta.105",
         "foldkit": "0.140.1"
+    },
+    "peerDependenciesMeta": {
+        "@effect/platform-browser": {
+            "optional": true
+        },
+        "foldkit": {
+            "optional": true
+        }
     }
 }

--- a/packages/ui/src/Internationalization.ts
+++ b/packages/ui/src/Internationalization.ts
@@ -1,0 +1,152 @@
+/**
+ * The languages tinyburg speaks, how a running app decides which one to use,
+ * and the locale-aware formatting that follows from the choice.
+ *
+ * Deliberately not re-exported from the package index: servers and the
+ * Discord bot import `@tinyburg/ui/Internationalization` directly, and the
+ * index pulls in the foldkit components they have no use for.
+ *
+ * @since 1.0.0
+ */
+
+import { DateTime, Schema as S } from "effect";
+
+/**
+ * A language tinyburg has translations for.
+ *
+ * @since 1.0.0
+ * @category Models
+ */
+export const Language = S.Literals(["en", "de", "es", "fr"]);
+
+/**
+ * @since 1.0.0
+ * @category Models
+ */
+export type Language = typeof Language.Type;
+
+/**
+ * The language used when negotiation finds nothing better.
+ *
+ * @since 1.0.0
+ * @category Models
+ */
+export const defaultLanguage: Language = "en";
+
+const languages: ReadonlyArray<Language> = ["en", "de", "es", "fr"];
+
+/**
+ * Walks candidate tags in order and returns the first whose primary subtag
+ * names a supported language (`de-AT` matches `de`, `es-419` matches `es`).
+ */
+const fromCandidates = (candidates: ReadonlyArray<string>): Language => {
+    for (const candidate of candidates) {
+        const primary = candidate.trim().toLowerCase().split("-")[0];
+        const match = languages.find((language) => language === primary);
+        if (match !== undefined) return match;
+    }
+    return defaultLanguage;
+};
+
+/**
+ * Negotiation for the browser. Call with
+ * `navigator.languages ?? [navigator.language]`; the list is already in
+ * preference order.
+ *
+ * @since 1.0.0
+ * @category Negotiation
+ */
+export const fromNavigator: (candidates: ReadonlyArray<string>) => Language = fromCandidates;
+
+/**
+ * Negotiation for an `Accept-Language` header: parses q-values, drops
+ * wildcards and rejected (`q=0`) ranges, and sorts by descending quality.
+ *
+ * @since 1.0.0
+ * @category Negotiation
+ */
+export const fromAcceptLanguage = (header: string | undefined): Language => {
+    if (header === undefined) return defaultLanguage;
+
+    const candidates = header
+        .split(",")
+        .flatMap((part) => {
+            const [tag = "", ...parameters] = part.split(";").map((piece) => piece.trim());
+
+            let quality = 1;
+            for (const parameter of parameters) {
+                if (parameter.toLowerCase().startsWith("q=")) {
+                    const parsed = Number(parameter.slice(2));
+                    if (!Number.isNaN(parsed)) quality = parsed;
+                }
+            }
+
+            return tag === "" || tag === "*" || quality <= 0 ? [] : [{ tag, quality }];
+        })
+        .sort((left, right) => right.quality - left.quality)
+        .map(({ tag }) => tag);
+
+    return fromCandidates(candidates);
+};
+
+/**
+ * Negotiation for a Discord interaction locale (`interaction.locale`), a
+ * single tag like `en-GB` or `es-419`.
+ *
+ * @since 1.0.0
+ * @category Negotiation
+ */
+export const fromDiscordLocale = (locale: string | undefined): Language =>
+    fromCandidates(locale === undefined ? [] : [locale]);
+
+const intlLocales: Record<Language, string> = {
+    en: "en-US",
+    de: "de-DE",
+    es: "es-ES",
+    fr: "fr-FR",
+};
+
+/**
+ * The full Intl locale tag used for formatting in a given language.
+ *
+ * @since 1.0.0
+ * @category Formatting
+ */
+export const intlLocale = (language: Language): string => intlLocales[language];
+
+/**
+ * A long date, e.g. "January 5, 2026" / "5. Januar 2026".
+ *
+ * @since 1.0.0
+ * @category Formatting
+ */
+export const longDate = (language: Language, when: DateTime.Utc): string =>
+    DateTime.format(when, { locale: intlLocale(language), month: "long", day: "numeric", year: "numeric" });
+
+/**
+ * A relative phrase for how long ago `when` was as of `asOf`: "now" under 90
+ * seconds, then minutes under an hour, hours under a day, days under thirty,
+ * and a {@link longDate} beyond that. `Intl.RelativeTimeFormat` with
+ * `numeric: "auto"` supplies the idiomatic forms ("yesterday", "gestern")
+ * and plural rules per language.
+ *
+ * @since 1.0.0
+ * @category Formatting
+ */
+export const relativeTime = (language: Language, asOf: DateTime.Utc, when: DateTime.Utc): string => {
+    const formatter = new Intl.RelativeTimeFormat(intlLocale(language), { numeric: "auto" });
+
+    const seconds = Math.round((DateTime.toEpochMillis(asOf) - DateTime.toEpochMillis(when)) / 1000);
+    if (seconds < 90) return formatter.format(0, "second");
+
+    const minutes = Math.round(seconds / 60);
+    if (minutes < 60) return formatter.format(-minutes, "minute");
+
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) return formatter.format(-hours, "hour");
+
+    const days = Math.round(hours / 24);
+    if (days < 30) return formatter.format(-days, "day");
+
+    return longDate(language, when);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@effect/sql-pg':
         specifier: 4.0.0-beta.105
         version: 4.0.0-beta.105(effect@4.0.0-beta.105)
+      '@tinyburg/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       dfx:
         specifier: 1.0.15
         version: 1.0.15(effect@4.0.0-beta.105)
@@ -258,6 +261,9 @@ importers:
       '@tinyburg/trading-sdk':
         specifier: workspace:*
         version: link:../../packages/trading-sdk
+      '@tinyburg/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       effect:
         specifier: 4.0.0-beta.105
         version: 4.0.0-beta.105


### PR DESCRIPTION
Foundation for Elm-style i18n (en/de/es/fr) across the sites. No new workspace package: the shared bits live in packages/ui/src/Internationalization.ts.

- Language schema (S.Literals) and defaultLanguage
- Negotiation: fromNavigator, fromAcceptLanguage (q-value parsing), fromDiscordLocale
- Intl-based formatting: intlLocale, longDate, relativeTime (same thresholds as the hand-rolled formatter it replaces)

Deliberately not re-exported from the package index, so the tinyburg.app server and the Discord bot can import @tinyburg/ui/Internationalization without pulling in the foldkit components. foldkit and @effect/platform-browser become optional peers for the same reason (the bot has neither, and the module needs neither).

Also wires the dependency and project reference into tinyburg.app, authproxy, social-circles and discord-bot so the per-app PRs stay conflict-free.

Merge this first; the five i18n/* app PRs are stacked on it.