### PR TITLE
Localize the tinyburg.app client (en/de/es/fr)

### DIFF
--- a/apps/tinyburg.app/client/backend.ts
+++ b/apps/tinyburg.app/client/backend.ts
@@ -52,7 +52,9 @@ export type SessionState = typeof SessionState.Type;
 
 const LinkedTower = S.Struct({ playerId: S.String, createdAt: S.DateTimeUtc });
 
-export const LinkedTowers = AsyncData.Schema(S.Array(LinkedTower), S.String);
+// The failure is a key the view resolves into the visitor's language, not a
+// finished sentence: this command runs without knowing which language that is.
+export const LinkedTowers = AsyncData.Schema(S.Array(LinkedTower), S.Literals(["loadFailed"]));
 export type LinkedTowers = typeof LinkedTowers.schema.Type;
 
 export const GotSession = m("GotSession", { session: SessionState });
@@ -60,7 +62,7 @@ export const GotSession = m("GotSession", { session: SessionState });
 /** The outcome of a towers fetch; update folds it into the current state with
  *  `AsyncData.settle`, which keeps held data as Stale on failure. */
 export const SettledLinkedTowers = m("SettledLinkedTowers", {
-    result: S.Result(S.Array(LinkedTower), S.String),
+    result: S.Result(S.Array(LinkedTower), S.Literals(["loadFailed"])),
 });
 
 /** Asks the server who this browser is. */
@@ -89,10 +91,6 @@ export const FetchLinkedTowers = Command.define("FetchLinkedTowers", {
         // The session expired or was signed out elsewhere; re-running the
         // gating sends the visitor back to login.
         Effect.catchTag("Unauthorized", () => Effect.succeed(GotSession({ session: SignedOut() }))),
-        Effect.catch(() =>
-            Effect.succeed(
-                SettledLinkedTowers({ result: Result.fail("We couldn't load your towers. Please try again.") })
-            )
-        )
+        Effect.catch(() => Effect.succeed(SettledLinkedTowers({ result: Result.fail("loadFailed") })))
     ),
 });

--- a/apps/tinyburg.app/client/entry.ts
+++ b/apps/tinyburg.app/client/entry.ts
@@ -3,7 +3,7 @@ import "./styles/global.css";
 import { Runtime } from "foldkit";
 
 import { BackendLive } from "./backend.ts";
-import { ChangedUrl, ClickedLink, init, initialLanguage, Model, update, view, viewTransition } from "./main.ts";
+import { ChangedUrl, ClickedLink, Model, init, initialLanguage, update, view, viewTransition } from "./main.ts";
 
 const application = Runtime.makeApplication({
     Model,

--- a/apps/tinyburg.app/client/entry.ts
+++ b/apps/tinyburg.app/client/entry.ts
@@ -3,7 +3,7 @@ import "./styles/global.css";
 import { Runtime } from "foldkit";
 
 import { BackendLive } from "./backend.ts";
-import { ChangedUrl, ClickedLink, Model, init, update, view, viewTransition } from "./main.ts";
+import { ChangedUrl, ClickedLink, init, initialLanguage, Model, update, view, viewTransition } from "./main.ts";
 
 const application = Runtime.makeApplication({
     Model,
@@ -18,5 +18,8 @@ const application = Runtime.makeApplication({
         onUrlChange: (url) => ChangedUrl({ url }),
     },
 });
+
+// index.html is served statically, so its `lang` can only be corrected here.
+document.documentElement.lang = initialLanguage;
 
 Runtime.run(application);

--- a/apps/tinyburg.app/client/main.ts
+++ b/apps/tinyburg.app/client/main.ts
@@ -2,7 +2,7 @@ import { Effect, Match, Option, Schema as S } from "effect";
 
 import type { Document, Html, HtmlBuilder } from "foldkit/html";
 
-import { fromNavigator, Language } from "@tinyburg/ui/Internationalization";
+import { Language, fromNavigator } from "@tinyburg/ui/Internationalization";
 import { AsyncData, Command, Dom, Navigation, Render, type Runtime, Url } from "foldkit";
 import { createLazy } from "foldkit/html";
 import { m } from "foldkit/message";
@@ -19,7 +19,7 @@ import {
     SettledLinkedTowers,
     SignedOut,
 } from "./backend.ts";
-import { type Messages, messagesFor, type TitleMessages } from "./messages/index.ts";
+import { type Messages, type TitleMessages, messagesFor } from "./messages/index.ts";
 import { aboutView } from "./pages/about.ts";
 import {
     AccountMessage,

--- a/apps/tinyburg.app/client/main.ts
+++ b/apps/tinyburg.app/client/main.ts
@@ -2,6 +2,7 @@ import { Effect, Match, Option, Schema as S } from "effect";
 
 import type { Document, Html, HtmlBuilder } from "foldkit/html";
 
+import { fromNavigator, Language } from "@tinyburg/ui/Internationalization";
 import { AsyncData, Command, Dom, Navigation, Render, type Runtime, Url } from "foldkit";
 import { createLazy } from "foldkit/html";
 import { m } from "foldkit/message";
@@ -18,6 +19,7 @@ import {
     SettledLinkedTowers,
     SignedOut,
 } from "./backend.ts";
+import { type Messages, messagesFor, type TitleMessages } from "./messages/index.ts";
 import { aboutView } from "./pages/about.ts";
 import {
     AccountMessage,
@@ -50,8 +52,19 @@ export const Model = S.Struct({
     linkedTowers: LinkedTowers.schema,
     wizard: WizardModel,
     account: AccountModel,
+    language: Language,
 });
 export type Model = typeof Model.Type;
+
+/**
+ * Negotiated once from the browser's preferences at module load (precedent:
+ * the module-scope `matchMedia` below). There is no switcher yet, so the
+ * language is plain model data that never changes after init. Guarded for the
+ * node test environment, which has no `navigator`.
+ */
+export const initialLanguage = fromNavigator(
+    typeof navigator === "undefined" ? [] : (navigator.languages ?? [navigator.language])
+);
 
 // MESSAGE
 
@@ -251,6 +264,7 @@ export const init: Runtime.RoutingApplicationInit<Model, Message, void, Backend>
                 linkedTowers: LinkedTowers.Idle(),
                 wizard: initialWizard,
                 account: initialAccount,
+                language: initialLanguage,
             },
             route
         )
@@ -260,22 +274,22 @@ export const init: Runtime.RoutingApplicationInit<Model, Message, void, Backend>
 
 // VIEW
 
-const routeTitle = (route: AppRoute): string =>
+const routeTitle = (route: AppRoute, titles: TitleMessages): string =>
     Match.value(route).pipe(
         Match.withReturnType<string>(),
         Match.tagsExhaustive({
-            Home: () => "TinyTower Trading | Trade Bitizens, Costumes & More",
-            About: () => "About | Tinyburg",
-            Login: () => "Log In | Tinyburg",
-            Privacy: () => "Privacy Policy | Tinyburg",
-            Terms: () => "Terms of Service | Tinyburg",
-            Sponsors: () => "Sponsors | Tinyburg",
-            Developers: () => "Developers | Tinyburg",
-            DeveloperApps: () => "OAuth Applications | Tinyburg",
-            TowerMe: () => "My Towers | Tinyburg",
-            TowerLink: () => "Link Your Tower | Tinyburg",
-            Account: () => "Account & Security | Tinyburg",
-            NotFound: () => "Page Not Found | Tinyburg",
+            Home: () => titles.home,
+            About: () => titles.about,
+            Login: () => titles.login,
+            Privacy: () => titles.privacy,
+            Terms: () => titles.terms,
+            Sponsors: () => titles.sponsors,
+            Developers: () => titles.developers,
+            DeveloperApps: () => titles.developerApps,
+            TowerMe: () => titles.towerMe,
+            TowerLink: () => titles.towerLink,
+            Account: () => titles.account,
+            NotFound: () => titles.notFound,
         })
     );
 
@@ -288,26 +302,34 @@ const lazyDevelopers = createLazy();
 const lazyDeveloperApps = createLazy();
 const lazyNotFound = createLazy();
 
-const pageView = (model: Model, h: HtmlBuilder<Message>): Html =>
+// The msgs slices ride in every lazy arg array (`messagesFor` is
+// reference-stable per language, so memoization still holds); leaving one out
+// would silently pin stale copy if a language switcher ever lands.
+const pageView = (model: Model, msgs: Messages, h: HtmlBuilder<Message>): Html =>
     Match.value(model.route).pipe(
         Match.withReturnType<Html>(),
         Match.tagsExhaustive({
-            Home: () => lazyHome(homeView, [h]),
-            About: () => lazyAbout(aboutView, [h]),
-            Login: ({ error, returnTo }) => loginView(h, returnTo, error),
+            Home: () => lazyHome(homeView, [h, msgs.home, msgs.shared]),
+            About: () => lazyAbout(aboutView, [h, msgs.about, msgs.shared]),
+            Login: ({ error, returnTo }) => loginView(h, msgs.login, msgs.shared, returnTo, error),
             Privacy: () => lazyPrivacy(privacyView, [h]),
             Terms: () => lazyTerms(termsView, [h]),
-            Sponsors: () => lazySponsors(sponsorsView, [h]),
-            Developers: () => lazyDevelopers(developersView, [h]),
-            DeveloperApps: () => lazyDeveloperApps(developerAppsView, [h]),
+            Sponsors: () => lazySponsors(sponsorsView, [h, msgs.sponsors, msgs.shared]),
+            Developers: () => lazyDevelopers(developersView, [h, msgs.developers, msgs.shared]),
+            DeveloperApps: () => lazyDeveloperApps(developerAppsView, [h, msgs.developerApps, msgs.shared]),
             // Gated pages render nothing until the session answer lands;
             // enterRoute has already sent a signed out visitor to login.
             TowerMe: () =>
-                model.session._tag === "SignedIn" ? towerMeView(h, model.session.user, model.linkedTowers) : h.empty,
-            TowerLink: () => (model.session._tag === "SignedIn" ? towerLinkView(h, model.wizard) : h.empty),
+                model.session._tag === "SignedIn"
+                    ? towerMeView(h, msgs.towerMe, msgs.shared, model.language, model.session.user, model.linkedTowers)
+                    : h.empty,
+            TowerLink: () =>
+                model.session._tag === "SignedIn" ? towerLinkView(h, msgs.towerLink, model.wizard) : h.empty,
             Account: () =>
-                model.session._tag === "SignedIn" ? accountView(h, model.account, model.session.user) : h.empty,
-            NotFound: () => lazyNotFound(notFoundView, [h]),
+                model.session._tag === "SignedIn"
+                    ? accountView(h, msgs.account, model.language, model.account, model.session.user)
+                    : h.empty,
+            NotFound: () => lazyNotFound(notFoundView, [h, msgs.notFound, msgs.shared]),
         })
     );
 
@@ -322,10 +344,13 @@ const pageKey = (model: Model): string =>
         ? `${model.route._tag}#pending`
         : model.route._tag;
 
-export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
-    title: routeTitle(model.route),
-    body: h.div([], [clouds(h), h.keyed("div")(pageKey(model), [], [pageView(model, h)])]),
-});
+export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
+    const msgs = messagesFor(model.language);
+    return {
+        title: routeTitle(model.route, msgs.titles),
+        body: h.div([], [clouds(h), h.keyed("div")(pageKey(model), [], [pageView(model, msgs, h)])]),
+    };
+};
 
 // VIEW TRANSITION
 

--- a/apps/tinyburg.app/client/messages/de.ts
+++ b/apps/tinyburg.app/client/messages/de.ts
@@ -1,0 +1,383 @@
+import type { Messages } from "./types.ts";
+
+/**
+ * German. Register: formal "Sie" throughout.
+ *
+ * Glossary kept in English: Tinyburg, TinyTower, Bitizen(s), Bux, brand and
+ * provider names (Google, Discord, GitHub, Reddit, NimbleBit). "Floors",
+ * "towers" and "friends" translate normally (Etagen, Türme, Freunde).
+ */
+export const de: Messages = {
+    shared: {
+        back: "Zurück",
+        backToHome: "← Zurück zur Startseite",
+        floors: {
+            food: "🍕 Essen",
+            retail: "🛍️ Handel",
+            service: "✂️ Service",
+            creative: "🎨 Kreativ",
+            recreation: "🎮 Freizeit",
+            residential: "🛏️ Wohnen",
+            lobby: "🚪 Lobby",
+        },
+    },
+    titles: {
+        home: "TinyTower-Tauschbörse | Bitizens, Kostüme & mehr tauschen",
+        about: "Über uns | Tinyburg",
+        login: "Anmelden | Tinyburg",
+        privacy: "Datenschutzerklärung | Tinyburg",
+        terms: "Nutzungsbedingungen | Tinyburg",
+        sponsors: "Sponsoren | Tinyburg",
+        developers: "Entwickler | Tinyburg",
+        developerApps: "OAuth-Anwendungen | Tinyburg",
+        towerMe: "Meine Türme | Tinyburg",
+        towerLink: "Turm verknüpfen | Tinyburg",
+        account: "Konto & Sicherheit | Tinyburg",
+        notFound: "Seite nicht gefunden | Tinyburg",
+    },
+    home: {
+        nav: {
+            browseTrades: "Angebote durchstöbern",
+            bitizens: "Bitizens",
+            costumes: "Kostüme",
+            about: "Über uns",
+        },
+        logIn: "Anmelden",
+        // REVIEW: "Tauschbörse" chosen over a literal "Trading" to read naturally.
+        heroTitle: "TinyTower-Tauschbörse",
+        heroTagline:
+            "Der Community-Marktplatz, um Bitizens, Kostüme, Haustiere und mehr mit TinyTower-Spielern aus aller Welt zu tauschen",
+        startTrading: "Jetzt tauschen",
+        learnMore: "Mehr erfahren",
+        featuresHeading: "Was können Sie tauschen?",
+        features: {
+            tradeBitizens: {
+                title: "Bitizens tauschen",
+                description: "Finden Sie Traumjob-Bitizens für Ihren Turm oder tauschen Sie Duplikate ein",
+            },
+            costumesPets: {
+                title: "Kostüme & Haustiere",
+                description: "Sammeln Sie seltene Kostüme und niedliche Haustiere für Ihre Bitizens",
+            },
+            goldenTickets: {
+                title: "Goldene Tickets",
+                description: "Tauschen Sie Ressourcen und helfen Sie anderen Turmbauern",
+            },
+            community: {
+                title: "Community",
+                description: "Vernetzen Sie sich mit Tausenden aktiven TinyTower-Spielern",
+            },
+        },
+        stats: {
+            activeTraders: "Aktive Tauschpartner",
+            tradesCompleted: "Abgeschlossene Tauschgeschäfte",
+            bitizensTraded: "Getauschte Bitizens",
+        },
+        ctaHeading: "Bereit, Ihren Traumturm zu bauen?",
+        ctaBody: "Schließen Sie sich Tausenden Spielern an, die täglich Bitizens und Gegenstände tauschen",
+        ctaButton: "Kostenlos loslegen",
+        footerAbout: {
+            before: "Eine Community-getriebene Tauschplattform für TinyTower-Fans. Nicht mit NimbleBit verbunden. Der Quellcode ist auf ",
+            linkLabel: "GitHub",
+            after: " verfügbar.",
+        },
+        quickLinks: "Direktlinks",
+        community: "Community",
+        legal: "Rechtliches",
+        sponsors: "Sponsoren",
+        privacyPolicy: "Datenschutzerklärung",
+        termsOfService: "Nutzungsbedingungen",
+        copyright: "© 2026 Tinyburg. TinyTower ist eine Marke von NimbleBit LLC.",
+    },
+    about: {
+        title: "Über Tinyburg",
+        // REVIEW: tone-sensitive tagline.
+        tagline: "Verbindungen schaffen, ein Bitizen nach dem anderen",
+        whatIsHeading: "Was ist Tinyburg?",
+        whatIsBody:
+            "Tinyburg ist eine von der Community gebaute Tauschplattform von TinyTower-Fans. Wir machen es einfach, Traumjob-Bitizens zu finden, seltene Kostüme zu tauschen und sich mit Turmbauern aus aller Welt zu vernetzen.",
+        missionHeading: "Unsere Mission",
+        missions: {
+            findDreamJobbers: {
+                title: "Traumjob-Bitizens finden",
+                description:
+                    "Warten Sie nicht länger auf zufällige Bitizens. Durchsuchen Sie unsere Datenbank nach den perfekten 9-Punkte-Traumjob-Bitizens für Ihre Etagen.",
+            },
+            connectPlayers: {
+                title: "Spieler vernetzen",
+                description:
+                    "Einen Turm zu bauen macht gemeinsam mehr Spaß. Vernetzen Sie sich mit Tausenden aktiven Spielern, die tauschen und einander helfen möchten.",
+            },
+            collectEverything: {
+                title: "Alles sammeln",
+                description:
+                    "Von seltenen Kostümen bis zu niedlichen Haustieren: Tauschen Sie sich zu einer vollständigen Sammlung.",
+            },
+        },
+        howHeading: "So funktioniert's",
+        steps: {
+            signUp: {
+                title: "Registrieren",
+                description: "Erstellen Sie Ihr Konto in Sekunden mit Google oder Discord",
+            },
+            linkTower: {
+                title: "Turm verknüpfen",
+                description: "Verknüpfen Sie Ihren Turm über die Cloud-Sync-Funktion von Nimblebit",
+            },
+            browseTrade: {
+                title: "Stöbern & tauschen",
+                description: "Finden Sie, was Sie brauchen, und vernetzen Sie sich mit anderen Spielern",
+            },
+            buildDream: {
+                title: "Traumturm bauen",
+                description: "Füllen Sie jede Etage mit Traumjob-Bitizens und seltenen Gegenständen",
+            },
+        },
+        communityHeading: "Community zuerst",
+        communityBody:
+            "Tinyburg wird von leidenschaftlichen TinyTower-Spielern gebaut und gepflegt. Wir sind nicht mit NimbleBit verbunden, teilen aber die Liebe zu kleinen Pixeln und hohen Türmen. Unser Ziel ist es, die TinyTower-Community noch vernetzter und hilfsbereiter zu machen.",
+        joinDiscord: "Unserem Discord beitreten",
+        openSourceHeading: "Open Source",
+        openSourceBody:
+            "Tinyburg ist ein Open-Source-Projekt. Wir glauben an Transparenz und Beiträge aus der Community. Schauen Sie sich unseren Code an, melden Sie Fehler oder steuern Sie Funktionen auf GitHub bei.",
+        viewOnGithub: "Auf GitHub ansehen",
+        ourSponsors: "Unsere Sponsoren",
+        faqHeading: "Häufig gestellte Fragen",
+        faqs: {
+            free: {
+                question: "F: Ist Tinyburg kostenlos?",
+                answer: "A: Ja! Tinyburg ist völlig kostenlos. Wir sind ein Community-Projekt von Spielern, die das Spiel lieben.",
+            },
+            affiliated: {
+                question: "F: Ist das mit NimbleBit verbunden?",
+                answer: "A: Nein, Tinyburg ist ein unabhängiges Fanprojekt. Wir sind in keiner Weise mit NimbleBit LLC verbunden oder von NimbleBit LLC unterstützt.",
+            },
+            trades: {
+                question: "F: Wie funktionieren Tauschgeschäfte?",
+                answer: "A: Tinyburg hilft Ihnen, Tauschpartner zu finden und den Austausch zu koordinieren. Der eigentliche Tausch kann je nach Gegenstand über verschiedene Wege ablaufen, etwa über Geschenke oder das Anpassen von Spielständen.",
+            },
+            dataSafe: {
+                question: "Sind meine Daten sicher?",
+                before: "Wir erheben nur, was für den Dienst nötig ist. Details finden Sie in unserer ",
+                linkLabel: "Datenschutzerklärung",
+                after: ".",
+            },
+        },
+    },
+    login: {
+        heading: "Willkommen bei Tinyburg",
+        subheading: "Melden Sie sich an oder erstellen Sie ein Konto, um loszulegen",
+        problems: {
+            denied: "Die Anmeldung wurde abgebrochen. Sie können jederzeit dort weitermachen, wo Sie aufgehört haben.",
+            expired:
+                "Dieser Anmeldeversuch ist abgelaufen oder wurde unterbrochen. Bitte beginnen Sie erneut und prüfen Sie, ob Ihr Browser Cookies für diese Seite erlaubt.",
+            failed: "Wir konnten Ihre Anmeldung nicht abschließen. Bitte versuchen Sie es erneut.",
+        },
+        continueWithGoogle: "Weiter mit Google",
+        continueWithDiscord: "Weiter mit Discord",
+        perks: {
+            dreamJobs: "Traumjob-Bitizens finden",
+            trade: "Mit Tausenden Spielern tauschen",
+            collect: "Seltene Kostüme & Haustiere sammeln",
+        },
+        agreeBefore: "Indem Sie fortfahren, stimmen Sie unseren ",
+        termsOfService: "Nutzungsbedingungen",
+        agreeAnd: " und unserer ",
+        privacyPolicy: "Datenschutzerklärung",
+    },
+    account: {
+        backToTowers: "← Zurück zu meinen Türmen",
+        heading: (name) => `Konto von ${name}`,
+        notices: {
+            connected: "Verbunden. Sie können sich jetzt damit anmelden.",
+            alreadyConnected: "Dieses Konto war bereits verbunden.",
+            disconnected: "Getrennt.",
+            linkCancelled: "Das Verbinden dieses Kontos wurde abgebrochen.",
+        },
+        signedOutSessions: (count) =>
+            count === 1 ? "Aus 1 Sitzung abgemeldet." : `Aus ${count} Sitzungen abgemeldet.`,
+        problems: {
+            linkExpired:
+                "Dieser Versuch ist abgelaufen oder wurde unterbrochen. Bitte versuchen Sie erneut, das Konto zu verbinden.",
+            linkFailed: "Wir konnten dieses Konto nicht verbinden. Bitte versuchen Sie es erneut.",
+            accountTaken: "Dieses Konto ist bereits mit einem anderen Tinyburg-Konto verbunden.",
+            actionFailed: "Das hat nicht geklappt. Bitte versuchen Sie es erneut.",
+            lastSignInMethod: "Das ist Ihre einzige Anmeldemöglichkeit, deshalb muss sie verbunden bleiben.",
+        },
+        loadFailed: "Das konnte nicht geladen werden. Bitte versuchen Sie es erneut.",
+        sessionsHeading: "Ihre aktiven Anmeldungen",
+        sessionsBody:
+            "Jeder Browser mit einer Sitzung für dieses Konto. Melden Sie sich überall ab, wo Sie etwas nicht wiedererkennen.",
+        loadingSessions: "Ihre Sitzungen werden geladen...",
+        unknownDevice: "Unbekanntes Gerät",
+        deviceOn: (browser, platform) => `${browser} auf ${platform}`,
+        thisDevice: "Dieses Gerät",
+        lastActive: (when) => `Zuletzt aktiv: ${when}`,
+        signedInOn: (date) => `Angemeldet am ${date}`,
+        signOut: "Abmelden",
+        signOutThisBrowser: "In diesem Browser abmelden",
+        signOutOf: (name) => `Von ${name} abmelden`,
+        noOtherSessions: "Keine weiteren Sitzungen",
+        signOutOthers: (count) => (count === 1 ? "1 weitere Sitzung abmelden" : `${count} weitere Sitzungen abmelden`),
+        signOutEverywhere: "Überall abmelden",
+        methodsHeading: "Anmeldemethoden",
+        methodsBody: "Verbinden Sie weitere Anmeldemöglichkeiten, damit Sie immer wieder in dieses Konto zurückkommen.",
+        loading: "Wird geladen...",
+        disconnect: "Trennen",
+        disconnectProvider: (provider) => `${provider} trennen`,
+        lastMethodTitle: "Das ist die einzige Anmeldemöglichkeit, die Ihnen noch bleibt",
+        connect: "Verbinden →",
+    },
+    developers: {
+        title: "Tinyburg für Entwickler",
+        tagline: "Lassen Sie Spieler ihr Tinyburg-Konto in Ihrer App verwenden",
+        signInHeading: "Sign in with Tinyburg",
+        signInBody:
+            "Tinyburg ist ein OpenID-Connect-Provider. Sie bauen ein Begleit-Tool, ein Discord-Bot-Dashboard oder etwas anderes für die TinyTower-Community? Registrieren Sie eine OAuth-Anwendung, und Spieler melden sich mit demselben Konto an, mit dem sie auch tauschen – ganz ohne neue Passwörter.",
+        features: {
+            standardOidc: {
+                title: "Standard-OIDC",
+                description:
+                    "Authorization-Code-Flow mit PKCE und ES256-signierten ID-Tokens. Jede OpenID-Connect-Client-Bibliothek funktioniert auf Anhieb.",
+            },
+            minimalScopes: {
+                title: "Minimale Scopes",
+                description:
+                    "Apps sehen nur Identität, Anzeigenamen und Avatar eines Spielers. Nichts anderes verlässt Tinyburg.",
+            },
+            playerConsent: {
+                title: "Zustimmung der Spieler",
+                description:
+                    "Spieler genehmigen auf einem Zustimmungsbildschirm genau, was Ihre App sehen darf, bevor Tokens ausgestellt werden.",
+            },
+        },
+        gettingStartedHeading: "Erste Schritte",
+        steps: {
+            logIn: {
+                title: "Bei Tinyburg anmelden",
+                description: "Zum Registrieren von Anwendungen brauchen Sie ein Tinyburg-Konto",
+            },
+            register: {
+                title: "Anwendung registrieren",
+                description: "Vergeben Sie einen Namen und Ihre Redirect-URIs, dann erhalten Sie Client-ID und Secret",
+            },
+            point: {
+                title: "OIDC-Bibliothek auf uns zeigen lassen",
+                description:
+                    "Die meisten Bibliotheken brauchen nur die Discovery-URL unten, um sich selbst zu konfigurieren",
+            },
+            signIn: {
+                title: "Spieler melden sich an",
+                description: "Sie genehmigen Ihre App einmal und landen wieder auf Ihrer Redirect-URI",
+            },
+        },
+        redirectNote:
+            "Redirect-URIs müssen https verwenden, außer localhost während der Entwicklung. Client-Secrets werden einmalig bei der Registrierung angezeigt und gehasht gespeichert – bewahren Sie Ihres also sicher auf.",
+        endpointsHeading: "Endpunkte",
+        endpointsBody:
+            "Alles unten steht auch im Discovery-Dokument, die meisten Setups brauchen daher nur die erste URL.",
+        endpointNames: {
+            jwks: "JWKS",
+            discovery: "Discovery",
+            authorization: "Autorisierung",
+            token: "Token",
+            userinfo: "Userinfo",
+        },
+        scopesHeading: "Scopes",
+        scopeDescriptions: {
+            openid: "Ihre Tinyburg-Identität bestätigen",
+            profile: "Ihren Anzeigenamen und Avatar sehen",
+        },
+        readyHeading: "Bereit loszulegen?",
+        readyBefore:
+            "Registrieren Sie Ihre erste Anwendung und melden Sie Spieler an. Fragen oder irgendwo festgefahren? Fragen Sie im ",
+        discordLinkLabel: "Tinyburg-Discord",
+        readyAfter: " und wir helfen Ihnen weiter.",
+        yourApplications: "Ihre Anwendungen",
+        discoveryDocument: "Discovery-Dokument",
+    },
+    developerApps: {
+        heading: "OAuth-Anwendungen",
+        comingSoon: "Self-Service-Registrierung kommt bald",
+        comingSoonDetail:
+            "Sign in with Tinyburg funktioniert bereits. Fragen Sie im Discord, dann registrieren wir Ihre Anwendung bis dahin von Hand.",
+        readGuide: "← Integrationsleitfaden lesen",
+    },
+    sponsors: {
+        title: "Danke, Sponsoren!",
+        // REVIEW: figurative tagline.
+        tagline: "Die Menschen, die auf jeder Etage das Licht anlassen",
+        intro: "Tinyburg ist kostenlos, Open Source und wird von Freiwilligen betrieben. Die Server, die Datenbank und die Treuhandkasse für jeden Tausch werden von den großzügigen Menschen auf dieser Seite bezahlt, die das Projekt auf GitHub sponsern. Jeder Einzelne von ihnen macht den Turm ein Stück höher.",
+        becomeSponsor: "Sponsor werden",
+        currentHeading: "Aktuelle Sponsoren",
+        noSponsors: "Noch keine Sponsoren. Seien Sie der erste Bitizen auf dieser Etage!",
+        pastHeading: "Ehemalige Sponsoren",
+        pastBody: "Einmal Sponsor, immer geschätzt. Danke für die Unterstützung auf dem Weg!",
+        otherWaysHeading: "Weitere Möglichkeiten zu helfen",
+        otherWaysBody:
+            "Sponsern ist nicht der einzige Weg, Tinyburg zu unterstützen. Melden Sie Fehler, steuern Sie eine Funktion bei oder helfen Sie einfach anderen Turmbauern in der Community.",
+        starOnGithub: "Auf GitHub einen Stern geben",
+        joinDiscord: "Unserem Discord beitreten",
+    },
+    towerLink: {
+        backToTowers: "← Meine Türme",
+        heading: "Turm verknüpfen",
+        subheading: "Verbinden Sie Ihren TinyTower-Cloud-Spielstand und tauschen Sie mit Spielern aus aller Welt",
+        step1: "Schritt 1 von 2",
+        step2: "Schritt 2 von 2",
+        friendCodeLabel: "Freundescode",
+        friendCodeTitle: "Bis zu 5 Buchstaben oder Ziffern",
+        friendCodeHint: "Sie finden ihn im Freunde-Tab in TinyTower",
+        emailLabel: "Cloud-Sync-E-Mail",
+        emailHint:
+            "Die E-Mail-Adresse, unter der Ihr Cloud-Spielstand registriert ist. Nimblebit sendet einen Bestätigungscode dorthin.",
+        sending: "Wird gesendet...",
+        sendCode: "Bestätigungscode senden",
+        sentCodeBefore: "📬 Nimblebit hat einen Bestätigungscode an ",
+        sentCodeAfter: " gesendet. Es kann eine Minute dauern, bis er ankommt.",
+        codeLabel: "Bestätigungscode",
+        codeHint: "Keine E-Mail? Prüfen Sie Ihren Spam-Ordner",
+        linked: "Verknüpft! Weiterleitung...",
+        verifying: "Wird geprüft...",
+        linkMyTower: "Meinen Turm verknüpfen",
+        goBack: "← Zurück",
+        sent: "Gesendet!",
+        resend: "E-Mail erneut senden",
+        errors: {
+            requestFailed:
+                "Wir konnten Ihren Turm nicht erreichen. Bitte prüfen Sie Ihren Freundescode und versuchen Sie es erneut.",
+            verifyFailed:
+                "Dieser Code hat nicht funktioniert. Bitte prüfen Sie ihn und versuchen Sie es erneut, oder lassen Sie die E-Mail erneut senden.",
+            resendFailed: "Wir konnten die E-Mail nicht erneut senden. Bitte versuchen Sie es gleich noch einmal.",
+        },
+    },
+    towerMe: {
+        avatarAlt: (name) => `Avatar von ${name}`,
+        // REVIEW: playful title.
+        mayor: "🏙️ Bürgermeister von Tinyburg",
+        signOut: "Abmelden",
+        towersHeading: "Meine Türme",
+        linkATower: "+ Turm verknüpfen",
+        noTowers: "Noch keine Türme verknüpft",
+        noTowersDetailLong:
+            "Verknüpfen Sie Ihren TinyTower-Spielstand, um Ihre Bitizens zu synchronisieren und mit Spielern aus aller Welt zu tauschen.",
+        noTowersDetailShort: "Verknüpfen Sie Ihren TinyTower-Spielstand, um mit dem Tauschen zu beginnen.",
+        loadingTowers: "Ihre Türme werden geladen...",
+        towersLoadFailed: "Wir konnten Ihre Türme nicht laden. Bitte versuchen Sie es erneut.",
+        linkedOn: (date) => `Verknüpft am ${date}`,
+        accountRow: {
+            title: "Konto & Sicherheit",
+            detail: "Verwalten Sie, wo Sie angemeldet sind und wie Sie sich anmelden",
+        },
+        developerRow: {
+            title: "Entwicklerportal",
+            detail: "Registrieren Sie OAuth-Apps, die Nutzer mit Tinyburg anmelden",
+        },
+    },
+    notFound: {
+        heading: "Etage nicht gefunden",
+        body: "Vielleicht haben die Bitizens diese Etage verlegt? Versuchen Sie es in der Lobby!",
+        goHome: "Zur Startseite",
+        goBack: "Zurück",
+    },
+};

--- a/apps/tinyburg.app/client/messages/en.ts
+++ b/apps/tinyburg.app/client/messages/en.ts
@@ -1,0 +1,364 @@
+import type { Messages } from "./types.ts";
+
+/** English: the source copy, moved verbatim from the pages. */
+export const en: Messages = {
+    shared: {
+        back: "Back",
+        backToHome: "← Back to Home",
+        floors: {
+            food: "🍕 Food",
+            retail: "🛍️ Retail",
+            service: "✂️ Service",
+            creative: "🎨 Creative",
+            recreation: "🎮 Recreation",
+            residential: "🛏️ Residential",
+            lobby: "🚪 Lobby",
+        },
+    },
+    titles: {
+        home: "TinyTower Trading | Trade Bitizens, Costumes & More",
+        about: "About | Tinyburg",
+        login: "Log In | Tinyburg",
+        privacy: "Privacy Policy | Tinyburg",
+        terms: "Terms of Service | Tinyburg",
+        sponsors: "Sponsors | Tinyburg",
+        developers: "Developers | Tinyburg",
+        developerApps: "OAuth Applications | Tinyburg",
+        towerMe: "My Towers | Tinyburg",
+        towerLink: "Link Your Tower | Tinyburg",
+        account: "Account & Security | Tinyburg",
+        notFound: "Page Not Found | Tinyburg",
+    },
+    home: {
+        nav: {
+            browseTrades: "Browse Trades",
+            bitizens: "Bitizens",
+            costumes: "Costumes",
+            about: "About",
+        },
+        logIn: "Log In",
+        heroTitle: "TinyTower Trading",
+        heroTagline:
+            "The community marketplace for trading bitizens, costumes, pets, and more with TinyTower players worldwide",
+        startTrading: "Start Trading",
+        learnMore: "Learn More",
+        featuresHeading: "What Can You Trade?",
+        features: {
+            tradeBitizens: {
+                title: "Trade Bitizens",
+                description: "Find dream jobbers for your tower or trade away duplicates",
+            },
+            costumesPets: {
+                title: "Costumes & Pets",
+                description: "Collect rare costumes and adorable pets for your bitizens",
+            },
+            goldenTickets: {
+                title: "Golden Tickets",
+                description: "Exchange resources and help fellow tower builders",
+            },
+            community: {
+                title: "Community",
+                description: "Connect with thousands of active TinyTower players",
+            },
+        },
+        stats: {
+            activeTraders: "Active Traders",
+            tradesCompleted: "Trades Completed",
+            bitizensTraded: "Bitizens Traded",
+        },
+        ctaHeading: "Ready to Build Your Dream Tower?",
+        ctaBody: "Join thousands of players trading bitizens and items every day",
+        ctaButton: "Get Started Free",
+        footerAbout: {
+            before: "A community-driven trading platform for TinyTower enthusiasts. Not affiliated with NimbleBit. Source code is available on ",
+            linkLabel: "GitHub",
+            after: "",
+        },
+        quickLinks: "Quick Links",
+        community: "Community",
+        legal: "Legal",
+        sponsors: "Sponsors",
+        privacyPolicy: "Privacy Policy",
+        termsOfService: "Terms of Service",
+        copyright: "© 2026 Tinyburg. TinyTower is a trademark of NimbleBit LLC.",
+    },
+    about: {
+        title: "About Tinyburg",
+        tagline: "Building connections, one bitizen at a time",
+        whatIsHeading: "What is Tinyburg?",
+        whatIsBody:
+            "Tinyburg is a community-made trading platform built by TinyTower enthusiasts. We make it easy to find dream job bitizens, trade rare costumes, and connect with fellow tower builders from around the world.",
+        missionHeading: "Our Mission",
+        missions: {
+            findDreamJobbers: {
+                title: "Find Dream Jobbers",
+                description:
+                    "Stop waiting for random bitizens. Search our database to find the perfect 9-skill dream jobbers for your floors.",
+            },
+            connectPlayers: {
+                title: "Connect Players",
+                description:
+                    "Building a tower is more fun together. Connect with thousands of active players ready to trade and help each other out.",
+            },
+            collectEverything: {
+                title: "Collect Everything",
+                description: "From rare costumes to adorable pets, trade your way to completing your collection.",
+            },
+        },
+        howHeading: "How It Works",
+        steps: {
+            signUp: {
+                title: "Sign Up",
+                description: "Create your account using Google or Discord in seconds",
+            },
+            linkTower: {
+                title: "Link Your Tower",
+                description: "Use Nimblebit's cloud sync feature to link your tower",
+            },
+            browseTrade: {
+                title: "Browse & Trade",
+                description: "Find what you need and connect with other players",
+            },
+            buildDream: {
+                title: "Build Your Dream Tower",
+                description: "Fill every floor with dream jobbers and rare items",
+            },
+        },
+        communityHeading: "Community First",
+        communityBody:
+            "Tinyburg is built and maintained by passionate TinyTower players. We're not affiliated with NimbleBit, but we share their love for tiny pixels and tall towers. Our goal is to make the TinyTower community even more connected and helpful.",
+        joinDiscord: "Join our Discord",
+        openSourceHeading: "Open Source",
+        openSourceBody:
+            "Tinyburg is an open source project. We believe in transparency and community contribution. Check out our code, report bugs, or contribute features on GitHub.",
+        viewOnGithub: "View on GitHub",
+        ourSponsors: "Our Sponsors",
+        faqHeading: "Frequently Asked Questions",
+        faqs: {
+            free: {
+                question: "Q: Is Tinyburg free?",
+                answer: "A: Yes! Tinyburg is completely free to use. We're a community project built by players who love the game.",
+            },
+            affiliated: {
+                question: "Q: Is this affiliated with NimbleBit?",
+                answer: "A: No, Tinyburg is an independent fan project. We're not affiliated with, endorsed by, or connected to NimbleBit LLC in any way.",
+            },
+            trades: {
+                question: "Q: How do trades work?",
+                answer: "A: Tinyburg helps you find traders and coordinate exchanges. The actual trading can leverage a couple different methods to exchange the items depending on what the items are, such as sending gifts or modifying save data.",
+            },
+            dataSafe: {
+                question: "Is my data safe?",
+                before: "We only collect what's necessary to provide the service. Check our ",
+                linkLabel: "Privacy Policy",
+                after: " for full details.",
+            },
+        },
+    },
+    login: {
+        heading: "Welcome to Tinyburg",
+        subheading: "Sign in or create an account to get started",
+        problems: {
+            denied: "Sign in was cancelled. You can pick up where you left off whenever you like.",
+            expired:
+                "That sign in attempt expired or was interrupted. Please start again, and check that your browser allows cookies for this site.",
+            failed: "We couldn't finish signing you in. Please try again.",
+        },
+        continueWithGoogle: "Continue with Google",
+        continueWithDiscord: "Continue with Discord",
+        perks: {
+            dreamJobs: "Find dream job bitizens",
+            trade: "Trade with thousands of players",
+            collect: "Collect rare costumes & pets",
+        },
+        agreeBefore: "By continuing, you agree to our ",
+        termsOfService: "Terms of Service",
+        agreeAnd: " and ",
+        privacyPolicy: "Privacy Policy",
+    },
+    account: {
+        backToTowers: "← Back to My Towers",
+        heading: (name) => `${name}'s account`,
+        notices: {
+            connected: "Connected. You can now sign in with it.",
+            alreadyConnected: "That account was already connected.",
+            disconnected: "Disconnected.",
+            linkCancelled: "Connecting that account was cancelled.",
+        },
+        signedOutSessions: (count) => (count === 1 ? "Signed out of 1 session." : `Signed out of ${count} sessions.`),
+        problems: {
+            linkExpired: "That attempt expired or was interrupted. Please try connecting again.",
+            linkFailed: "We couldn't connect that account. Please try again.",
+            accountTaken: "That account is already connected to a different Tinyburg account.",
+            actionFailed: "That didn't work. Please try again.",
+            lastSignInMethod: "That's your only way to sign in, so it has to stay connected.",
+        },
+        loadFailed: "We couldn't load this. Please try again.",
+        sessionsHeading: "Where You're Signed In",
+        sessionsBody: "Every browser holding a session for this account. Sign out of any you don't recognise.",
+        loadingSessions: "Loading your sessions...",
+        unknownDevice: "Unknown device",
+        deviceOn: (browser, platform) => `${browser} on ${platform}`,
+        thisDevice: "This device",
+        lastActive: (when) => `Last active ${when}`,
+        signedInOn: (date) => `Signed in ${date}`,
+        signOut: "Sign out",
+        signOutThisBrowser: "Sign out of this browser",
+        signOutOf: (name) => `Sign out of ${name}`,
+        noOtherSessions: "No other sessions",
+        signOutOthers: (count) => (count === 1 ? "Sign out 1 other session" : `Sign out ${count} other sessions`),
+        signOutEverywhere: "Sign out everywhere",
+        methodsHeading: "Sign-In Methods",
+        methodsBody: "Connect more ways to sign in, so you can always get back to this account.",
+        loading: "Loading...",
+        disconnect: "Disconnect",
+        disconnectProvider: (provider) => `Disconnect ${provider}`,
+        lastMethodTitle: "This is the only way you have left to sign in",
+        connect: "Connect →",
+    },
+    developers: {
+        title: "Tinyburg for Developers",
+        tagline: "Let players bring their Tinyburg account to your app",
+        signInHeading: "Sign in with Tinyburg",
+        signInBody:
+            "Tinyburg is an OpenID Connect provider. Building a companion tool, a Discord bot dashboard, or anything else for the TinyTower community? Register an OAuth application and players can sign in to it with the same account they use to trade, no new passwords required.",
+        features: {
+            standardOidc: {
+                title: "Standard OIDC",
+                description:
+                    "Authorization code flow with PKCE and ES256-signed id tokens. Any OpenID Connect client library works out of the box.",
+            },
+            minimalScopes: {
+                title: "Minimal Scopes",
+                description:
+                    "Apps only see a player's identity, display name, and avatar. Nothing else leaves Tinyburg.",
+            },
+            playerConsent: {
+                title: "Player Consent",
+                description:
+                    "Players approve exactly what your app can see on a consent screen before any tokens are issued.",
+            },
+        },
+        gettingStartedHeading: "Getting Started",
+        steps: {
+            logIn: {
+                title: "Log In to Tinyburg",
+                description: "You need a Tinyburg account to register applications",
+            },
+            register: {
+                title: "Register Your Application",
+                description: "Give it a name and your redirect uris, then grab your client id and secret",
+            },
+            point: {
+                title: "Point Your OIDC Library at Us",
+                description: "Most libraries only need the discovery url below to configure themselves",
+            },
+            signIn: {
+                title: "Players Sign In",
+                description: "They approve your app once and arrive back at your redirect uri",
+            },
+        },
+        redirectNote:
+            "Redirect uris must use https, except for localhost while you develop. Client secrets are shown once at registration and stored hashed, so keep yours somewhere safe.",
+        endpointsHeading: "Endpoints",
+        endpointsBody:
+            "Everything below is also published in the discovery document, so most setups only ever need the first url.",
+        endpointNames: {
+            jwks: "JWKS",
+            discovery: "Discovery",
+            authorization: "Authorization",
+            token: "Token",
+            userinfo: "Userinfo",
+        },
+        scopesHeading: "Scopes",
+        scopeDescriptions: {
+            openid: "Confirm your Tinyburg identity",
+            profile: "See your display name and avatar",
+        },
+        readyHeading: "Ready to Build?",
+        readyBefore:
+            "Register your first application and start signing players in. Questions or stuck on something? Ask in the ",
+        discordLinkLabel: "Tinyburg Discord",
+        readyAfter: " and we'll help you out.",
+        yourApplications: "Your Applications",
+        discoveryDocument: "Discovery Document",
+    },
+    developerApps: {
+        heading: "OAuth Applications",
+        comingSoon: "Self-serve registration is coming",
+        comingSoonDetail:
+            "Sign in with Tinyburg already works. Ask in the Discord and we'll register your application by hand in the meantime.",
+        readGuide: "← Read the integration guide",
+    },
+    sponsors: {
+        title: "Thank You, Sponsors!",
+        tagline: "The people keeping the lights on in every floor",
+        intro: "Tinyburg is free, open source, and run by volunteers. The servers, the database, and the treasury that escrows every trade are all paid for by the generous people on this page who sponsor the project on GitHub. Every single one of them makes the tower a little taller.",
+        becomeSponsor: "Become a Sponsor",
+        currentHeading: "Current Sponsors",
+        noSponsors: "No sponsors yet. Be the first bitizen on this floor!",
+        pastHeading: "Past Sponsors",
+        pastBody: "Once a sponsor, always appreciated. Thank you for helping along the way!",
+        otherWaysHeading: "Other Ways to Help",
+        otherWaysBody:
+            "Sponsoring is not the only way to support Tinyburg. Report bugs, contribute a feature, or just hang out and help other tower builders in the community.",
+        starOnGithub: "Star on GitHub",
+        joinDiscord: "Join our Discord",
+    },
+    towerLink: {
+        backToTowers: "← My Towers",
+        heading: "Link Your Tower",
+        subheading: "Connect your TinyTower cloud save to start trading with players worldwide",
+        step1: "Step 1 of 2",
+        step2: "Step 2 of 2",
+        friendCodeLabel: "Friend Code",
+        friendCodeTitle: "Up to 5 letters or numbers",
+        friendCodeHint: "You can find it on the Friends tab in TinyTower",
+        emailLabel: "Cloud Sync Email",
+        emailHint: "The email your cloud save is registered with. Nimblebit will send a verification code to it.",
+        sending: "Sending...",
+        sendCode: "Send Verification Code",
+        sentCodeBefore: "📬 Nimblebit sent a verification code to ",
+        sentCodeAfter: ". It can take a minute to arrive.",
+        codeLabel: "Verification Code",
+        codeHint: "No email? Check your spam folder",
+        linked: "Linked! Redirecting...",
+        verifying: "Verifying...",
+        linkMyTower: "Link My Tower",
+        goBack: "← Go back",
+        sent: "Sent!",
+        resend: "Resend email",
+        errors: {
+            requestFailed: "We couldn't reach your tower. Please double-check your friend code and try again.",
+            verifyFailed: "That code didn't work. Please check it and try again, or resend the email.",
+            resendFailed: "We couldn't resend the email. Please try again in a moment.",
+        },
+    },
+    towerMe: {
+        avatarAlt: (name) => `Avatar for ${name}`,
+        mayor: "🏙️ Mayor of Tinyburg",
+        signOut: "Sign Out",
+        towersHeading: "My Towers",
+        linkATower: "+ Link a Tower",
+        noTowers: "No towers linked yet",
+        noTowersDetailLong: "Link your TinyTower save to sync your bitizens and start trading with players worldwide.",
+        noTowersDetailShort: "Link your TinyTower save to start trading.",
+        loadingTowers: "Loading your towers...",
+        towersLoadFailed: "We couldn't load your towers. Please try again.",
+        linkedOn: (date) => `Linked ${date}`,
+        accountRow: {
+            title: "Account & Security",
+            detail: "Manage where you're signed in and how you sign in",
+        },
+        developerRow: {
+            title: "Developer Portal",
+            detail: "Register OAuth apps that sign users in with Tinyburg",
+        },
+    },
+    notFound: {
+        heading: "Floor Not Found",
+        body: "Maybe the bitizens moved this floor? Try the lobby instead!",
+        goHome: "Go Home",
+        goBack: "Go Back",
+    },
+};

--- a/apps/tinyburg.app/client/messages/es.ts
+++ b/apps/tinyburg.app/client/messages/es.ts
@@ -1,0 +1,377 @@
+import type { Messages } from "./types.ts";
+
+/**
+ * Spanish. Register: informal "tú" throughout.
+ *
+ * Glossary kept in English: Tinyburg, TinyTower, bitizen(s), bux, brand and
+ * provider names (Google, Discord, GitHub, Reddit, NimbleBit). "Floors",
+ * "towers" and "friends" translate normally (pisos, torres, amigos).
+ */
+export const es: Messages = {
+    shared: {
+        back: "Volver",
+        backToHome: "← Volver al inicio",
+        floors: {
+            food: "🍕 Comida",
+            retail: "🛍️ Tiendas",
+            service: "✂️ Servicios",
+            creative: "🎨 Creativo",
+            recreation: "🎮 Ocio",
+            residential: "🛏️ Residencial",
+            lobby: "🚪 Vestíbulo",
+        },
+    },
+    titles: {
+        home: "Intercambios de TinyTower | Intercambia bitizens, disfraces y más",
+        about: "Acerca de | Tinyburg",
+        login: "Iniciar sesión | Tinyburg",
+        privacy: "Política de privacidad | Tinyburg",
+        terms: "Términos del servicio | Tinyburg",
+        sponsors: "Patrocinadores | Tinyburg",
+        developers: "Desarrolladores | Tinyburg",
+        developerApps: "Aplicaciones OAuth | Tinyburg",
+        towerMe: "Mis torres | Tinyburg",
+        towerLink: "Vincula tu torre | Tinyburg",
+        account: "Cuenta y seguridad | Tinyburg",
+        notFound: "Página no encontrada | Tinyburg",
+    },
+    home: {
+        nav: {
+            browseTrades: "Ver intercambios",
+            bitizens: "Bitizens",
+            costumes: "Disfraces",
+            about: "Acerca de",
+        },
+        logIn: "Iniciar sesión",
+        heroTitle: "Intercambios de TinyTower",
+        heroTagline:
+            "El mercado de la comunidad para intercambiar bitizens, disfraces, mascotas y más con jugadores de TinyTower de todo el mundo",
+        startTrading: "Empieza a intercambiar",
+        learnMore: "Saber más",
+        featuresHeading: "¿Qué puedes intercambiar?",
+        features: {
+            tradeBitizens: {
+                title: "Intercambia bitizens",
+                description: "Encuentra bitizens con su empleo soñado para tu torre o intercambia tus duplicados",
+            },
+            costumesPets: {
+                title: "Disfraces y mascotas",
+                description: "Colecciona disfraces raros y mascotas adorables para tus bitizens",
+            },
+            goldenTickets: {
+                title: "Tickets dorados",
+                description: "Intercambia recursos y ayuda a otros constructores de torres",
+            },
+            community: {
+                title: "Comunidad",
+                description: "Conecta con miles de jugadores activos de TinyTower",
+            },
+        },
+        stats: {
+            activeTraders: "Jugadores activos",
+            tradesCompleted: "Intercambios completados",
+            bitizensTraded: "Bitizens intercambiados",
+        },
+        ctaHeading: "¿Listo para construir la torre de tus sueños?",
+        ctaBody: "Únete a miles de jugadores que intercambian bitizens y objetos cada día",
+        ctaButton: "Empieza gratis",
+        footerAbout: {
+            before: "Una plataforma de intercambios impulsada por la comunidad para fans de TinyTower. Sin afiliación con NimbleBit. El código fuente está disponible en ",
+            linkLabel: "GitHub",
+            after: ".",
+        },
+        quickLinks: "Enlaces rápidos",
+        community: "Comunidad",
+        legal: "Legal",
+        sponsors: "Patrocinadores",
+        privacyPolicy: "Política de privacidad",
+        termsOfService: "Términos del servicio",
+        copyright: "© 2026 Tinyburg. TinyTower es una marca de NimbleBit LLC.",
+    },
+    about: {
+        title: "Acerca de Tinyburg",
+        // REVIEW: tone-sensitive tagline.
+        tagline: "Creando conexiones, bitizen a bitizen",
+        whatIsHeading: "¿Qué es Tinyburg?",
+        whatIsBody:
+            "Tinyburg es una plataforma de intercambios creada por la comunidad de fans de TinyTower. Te facilitamos encontrar bitizens con su empleo soñado, intercambiar disfraces raros y conectar con constructores de torres de todo el mundo.",
+        missionHeading: "Nuestra misión",
+        missions: {
+            findDreamJobbers: {
+                title: "Encuentra empleados soñados",
+                description:
+                    "Deja de esperar bitizens al azar. Busca en nuestra base de datos los bitizens perfectos de 9 puntos con su empleo soñado para tus pisos.",
+            },
+            connectPlayers: {
+                title: "Conecta jugadores",
+                description:
+                    "Construir una torre es más divertido en compañía. Conecta con miles de jugadores activos listos para intercambiar y echarse una mano.",
+            },
+            collectEverything: {
+                title: "Coléccionalo todo",
+                description: "De disfraces raros a mascotas adorables, intercambia hasta completar tu colección.",
+            },
+        },
+        howHeading: "Cómo funciona",
+        steps: {
+            signUp: {
+                title: "Regístrate",
+                description: "Crea tu cuenta con Google o Discord en segundos",
+            },
+            linkTower: {
+                title: "Vincula tu torre",
+                description: "Usa la sincronización en la nube de Nimblebit para vincular tu torre",
+            },
+            browseTrade: {
+                title: "Explora e intercambia",
+                description: "Encuentra lo que necesitas y conecta con otros jugadores",
+            },
+            buildDream: {
+                title: "Construye la torre de tus sueños",
+                description: "Llena cada piso con empleados soñados y objetos raros",
+            },
+        },
+        communityHeading: "La comunidad primero",
+        communityBody:
+            "Tinyburg está creado y mantenido por jugadores apasionados de TinyTower. No estamos afiliados a NimbleBit, pero compartimos su amor por los píxeles pequeños y las torres altas. Nuestro objetivo es hacer que la comunidad de TinyTower esté aún más conectada y sea más colaborativa.",
+        joinDiscord: "Únete a nuestro Discord",
+        openSourceHeading: "Código abierto",
+        openSourceBody:
+            "Tinyburg es un proyecto de código abierto. Creemos en la transparencia y en las contribuciones de la comunidad. Revisa nuestro código, informa de errores o aporta funcionalidades en GitHub.",
+        viewOnGithub: "Ver en GitHub",
+        ourSponsors: "Nuestros patrocinadores",
+        faqHeading: "Preguntas frecuentes",
+        faqs: {
+            free: {
+                question: "P: ¿Tinyburg es gratis?",
+                answer: "R: ¡Sí! Tinyburg es completamente gratis. Somos un proyecto comunitario creado por jugadores que aman el juego.",
+            },
+            affiliated: {
+                question: "P: ¿Está afiliado a NimbleBit?",
+                answer: "R: No, Tinyburg es un proyecto de fans independiente. No estamos afiliados, respaldados ni conectados con NimbleBit LLC de ninguna manera.",
+            },
+            trades: {
+                question: "P: ¿Cómo funcionan los intercambios?",
+                answer: "R: Tinyburg te ayuda a encontrar jugadores y coordinar los intercambios. El intercambio en sí puede hacerse por distintos métodos según los objetos, como enviar regalos o modificar los datos de guardado.",
+            },
+            dataSafe: {
+                question: "¿Mis datos están seguros?",
+                before: "Solo recopilamos lo necesario para ofrecer el servicio. Consulta nuestra ",
+                linkLabel: "Política de privacidad",
+                after: " para conocer todos los detalles.",
+            },
+        },
+    },
+    login: {
+        heading: "Bienvenido a Tinyburg",
+        subheading: "Inicia sesión o crea una cuenta para empezar",
+        problems: {
+            denied: "El inicio de sesión se canceló. Puedes retomarlo cuando quieras.",
+            expired:
+                "Ese intento de inicio de sesión caducó o se interrumpió. Empieza de nuevo y comprueba que tu navegador permite cookies para este sitio.",
+            failed: "No pudimos completar tu inicio de sesión. Inténtalo de nuevo.",
+        },
+        continueWithGoogle: "Continuar con Google",
+        continueWithDiscord: "Continuar con Discord",
+        perks: {
+            dreamJobs: "Encuentra bitizens con su empleo soñado",
+            trade: "Intercambia con miles de jugadores",
+            collect: "Colecciona disfraces raros y mascotas",
+        },
+        agreeBefore: "Al continuar, aceptas nuestros ",
+        termsOfService: "Términos del servicio",
+        agreeAnd: " y nuestra ",
+        privacyPolicy: "Política de privacidad",
+    },
+    account: {
+        backToTowers: "← Volver a mis torres",
+        heading: (name) => `Cuenta de ${name}`,
+        notices: {
+            connected: "Conectada. Ya puedes iniciar sesión con ella.",
+            alreadyConnected: "Esa cuenta ya estaba conectada.",
+            disconnected: "Desconectada.",
+            linkCancelled: "La conexión de esa cuenta se canceló.",
+        },
+        signedOutSessions: (count) => (count === 1 ? "Se cerró 1 sesión." : `Se cerraron ${count} sesiones.`),
+        problems: {
+            linkExpired: "Ese intento caducó o se interrumpió. Intenta conectarla de nuevo.",
+            linkFailed: "No pudimos conectar esa cuenta. Inténtalo de nuevo.",
+            accountTaken: "Esa cuenta ya está conectada a otra cuenta de Tinyburg.",
+            actionFailed: "Eso no funcionó. Inténtalo de nuevo.",
+            lastSignInMethod: "Es tu única forma de iniciar sesión, así que debe seguir conectada.",
+        },
+        loadFailed: "No pudimos cargar esto. Inténtalo de nuevo.",
+        sessionsHeading: "Dónde tienes la sesión iniciada",
+        sessionsBody: "Cada navegador con una sesión de esta cuenta. Cierra la sesión en cualquiera que no reconozcas.",
+        loadingSessions: "Cargando tus sesiones...",
+        unknownDevice: "Dispositivo desconocido",
+        deviceOn: (browser, platform) => `${browser} en ${platform}`,
+        thisDevice: "Este dispositivo",
+        lastActive: (when) => `Última actividad: ${when}`,
+        signedInOn: (date) => `Sesión iniciada el ${date}`,
+        signOut: "Cerrar sesión",
+        signOutThisBrowser: "Cerrar sesión en este navegador",
+        signOutOf: (name) => `Cerrar sesión en ${name}`,
+        noOtherSessions: "No hay otras sesiones",
+        signOutOthers: (count) => (count === 1 ? "Cerrar la otra sesión" : `Cerrar las otras ${count} sesiones`),
+        signOutEverywhere: "Cerrar sesión en todas partes",
+        methodsHeading: "Métodos de inicio de sesión",
+        methodsBody: "Conecta más formas de iniciar sesión para poder volver siempre a esta cuenta.",
+        loading: "Cargando...",
+        disconnect: "Desconectar",
+        disconnectProvider: (provider) => `Desconectar ${provider}`,
+        lastMethodTitle: "Es la única forma que te queda de iniciar sesión",
+        connect: "Conectar →",
+    },
+    developers: {
+        title: "Tinyburg para desarrolladores",
+        tagline: "Deja que los jugadores lleven su cuenta de Tinyburg a tu app",
+        signInHeading: "Sign in with Tinyburg",
+        signInBody:
+            "Tinyburg es un proveedor de OpenID Connect. ¿Estás creando una herramienta complementaria, un panel para un bot de Discord o cualquier otra cosa para la comunidad de TinyTower? Registra una aplicación OAuth y los jugadores podrán iniciar sesión con la misma cuenta que usan para intercambiar, sin contraseñas nuevas.",
+        features: {
+            standardOidc: {
+                title: "OIDC estándar",
+                description:
+                    "Flujo de código de autorización con PKCE y tokens de identidad firmados con ES256. Cualquier biblioteca cliente de OpenID Connect funciona sin más.",
+            },
+            minimalScopes: {
+                title: "Scopes mínimos",
+                description:
+                    "Las apps solo ven la identidad, el nombre visible y el avatar del jugador. Nada más sale de Tinyburg.",
+            },
+            playerConsent: {
+                title: "Consentimiento del jugador",
+                description:
+                    "Los jugadores aprueban exactamente lo que tu app puede ver en una pantalla de consentimiento antes de emitirse ningún token.",
+            },
+        },
+        gettingStartedHeading: "Primeros pasos",
+        steps: {
+            logIn: {
+                title: "Inicia sesión en Tinyburg",
+                description: "Necesitas una cuenta de Tinyburg para registrar aplicaciones",
+            },
+            register: {
+                title: "Registra tu aplicación",
+                description: "Ponle un nombre y tus URIs de redirección, y obtén tu client id y tu secreto",
+            },
+            point: {
+                title: "Apunta tu biblioteca OIDC hacia nosotros",
+                description:
+                    "La mayoría de bibliotecas solo necesitan la URL de discovery de abajo para configurarse solas",
+            },
+            signIn: {
+                title: "Los jugadores inician sesión",
+                description: "Aprueban tu app una vez y vuelven a tu URI de redirección",
+            },
+        },
+        redirectNote:
+            "Las URIs de redirección deben usar https, salvo localhost mientras desarrollas. Los secretos de cliente se muestran una sola vez al registrarte y se guardan con hash, así que guarda el tuyo en un lugar seguro.",
+        endpointsHeading: "Endpoints",
+        endpointsBody:
+            "Todo lo de abajo también se publica en el documento de discovery, así que la mayoría de configuraciones solo necesitan la primera URL.",
+        endpointNames: {
+            jwks: "JWKS",
+            discovery: "Discovery",
+            authorization: "Autorización",
+            token: "Token",
+            userinfo: "Userinfo",
+        },
+        scopesHeading: "Scopes",
+        scopeDescriptions: {
+            openid: "Confirmar tu identidad de Tinyburg",
+            profile: "Ver tu nombre visible y tu avatar",
+        },
+        readyHeading: "¿Listo para construir?",
+        readyBefore:
+            "Registra tu primera aplicación y empieza a iniciar sesión a jugadores. ¿Dudas o atascado en algo? Pregunta en el ",
+        discordLinkLabel: "Discord de Tinyburg",
+        readyAfter: " y te ayudaremos.",
+        yourApplications: "Tus aplicaciones",
+        discoveryDocument: "Documento de discovery",
+    },
+    developerApps: {
+        heading: "Aplicaciones OAuth",
+        comingSoon: "El registro autoservicio está en camino",
+        comingSoonDetail:
+            "Sign in with Tinyburg ya funciona. Pregunta en el Discord y mientras tanto registraremos tu aplicación a mano.",
+        readGuide: "← Lee la guía de integración",
+    },
+    sponsors: {
+        title: "¡Gracias, patrocinadores!",
+        // REVIEW: figurative tagline.
+        tagline: "Las personas que mantienen las luces encendidas en cada piso",
+        intro: "Tinyburg es gratis, de código abierto y lo mantienen voluntarios. Los servidores, la base de datos y el depósito que custodia cada intercambio los pagan las personas generosas de esta página que patrocinan el proyecto en GitHub. Cada una de ellas hace la torre un poco más alta.",
+        becomeSponsor: "Hazte patrocinador",
+        currentHeading: "Patrocinadores actuales",
+        noSponsors: "Aún no hay patrocinadores. ¡Sé el primer bitizen de este piso!",
+        pastHeading: "Patrocinadores anteriores",
+        pastBody: "Quien fue patrocinador, siempre será apreciado. ¡Gracias por ayudar en el camino!",
+        otherWaysHeading: "Otras formas de ayudar",
+        otherWaysBody:
+            "Patrocinar no es la única forma de apoyar a Tinyburg. Informa de errores, aporta una funcionalidad o simplemente pasa el rato y ayuda a otros constructores de torres en la comunidad.",
+        starOnGithub: "Dale una estrella en GitHub",
+        joinDiscord: "Únete a nuestro Discord",
+    },
+    towerLink: {
+        backToTowers: "← Mis torres",
+        heading: "Vincula tu torre",
+        subheading:
+            "Conecta tu guardado en la nube de TinyTower para empezar a intercambiar con jugadores de todo el mundo",
+        step1: "Paso 1 de 2",
+        step2: "Paso 2 de 2",
+        friendCodeLabel: "Código de amigo",
+        friendCodeTitle: "Hasta 5 letras o números",
+        friendCodeHint: "Lo encontrarás en la pestaña Amigos de TinyTower",
+        emailLabel: "Correo de sincronización en la nube",
+        emailHint:
+            "El correo con el que está registrado tu guardado en la nube. Nimblebit enviará ahí un código de verificación.",
+        sending: "Enviando...",
+        sendCode: "Enviar código de verificación",
+        sentCodeBefore: "📬 Nimblebit envió un código de verificación a ",
+        sentCodeAfter: ". Puede tardar un minuto en llegar.",
+        codeLabel: "Código de verificación",
+        codeHint: "¿No llega el correo? Revisa tu carpeta de spam",
+        linked: "¡Vinculada! Redirigiendo...",
+        verifying: "Verificando...",
+        linkMyTower: "Vincular mi torre",
+        goBack: "← Volver",
+        sent: "¡Enviado!",
+        resend: "Reenviar correo",
+        errors: {
+            requestFailed: "No pudimos contactar con tu torre. Comprueba tu código de amigo e inténtalo de nuevo.",
+            verifyFailed: "Ese código no funcionó. Compruébalo e inténtalo de nuevo, o reenvía el correo.",
+            resendFailed: "No pudimos reenviar el correo. Inténtalo de nuevo en un momento.",
+        },
+    },
+    towerMe: {
+        avatarAlt: (name) => `Avatar de ${name}`,
+        // REVIEW: playful title.
+        mayor: "🏙️ Alcalde de Tinyburg",
+        signOut: "Cerrar sesión",
+        towersHeading: "Mis torres",
+        linkATower: "+ Vincular una torre",
+        noTowers: "Aún no hay torres vinculadas",
+        noTowersDetailLong:
+            "Vincula tu guardado de TinyTower para sincronizar tus bitizens y empezar a intercambiar con jugadores de todo el mundo.",
+        noTowersDetailShort: "Vincula tu guardado de TinyTower para empezar a intercambiar.",
+        loadingTowers: "Cargando tus torres...",
+        towersLoadFailed: "No pudimos cargar tus torres. Inténtalo de nuevo.",
+        linkedOn: (date) => `Vinculada el ${date}`,
+        accountRow: {
+            title: "Cuenta y seguridad",
+            detail: "Gestiona dónde tienes la sesión iniciada y cómo inicias sesión",
+        },
+        developerRow: {
+            title: "Portal de desarrolladores",
+            detail: "Registra apps OAuth que inician sesión de usuarios con Tinyburg",
+        },
+    },
+    notFound: {
+        heading: "Piso no encontrado",
+        body: "¿Quizá los bitizens movieron este piso? ¡Prueba en el vestíbulo!",
+        goHome: "Ir al inicio",
+        goBack: "Volver",
+    },
+};

--- a/apps/tinyburg.app/client/messages/fr.ts
+++ b/apps/tinyburg.app/client/messages/fr.ts
@@ -1,0 +1,378 @@
+import type { Messages } from "./types.ts";
+
+/**
+ * French. Register: informal "tu" throughout.
+ *
+ * Glossary kept in English: Tinyburg, TinyTower, bitizen(s), bux, brand and
+ * provider names (Google, Discord, GitHub, Reddit, NimbleBit). "Floors",
+ * "towers" and "friends" translate normally (étages, tours, amis).
+ */
+export const fr: Messages = {
+    shared: {
+        back: "Retour",
+        backToHome: "← Retour à l'accueil",
+        floors: {
+            food: "🍕 Restauration",
+            retail: "🛍️ Boutiques",
+            service: "✂️ Services",
+            creative: "🎨 Créatif",
+            recreation: "🎮 Loisirs",
+            residential: "🛏️ Résidentiel",
+            lobby: "🚪 Hall",
+        },
+    },
+    titles: {
+        home: "Échanges TinyTower | Échange des bitizens, des costumes et plus",
+        about: "À propos | Tinyburg",
+        login: "Connexion | Tinyburg",
+        privacy: "Politique de confidentialité | Tinyburg",
+        terms: "Conditions d'utilisation | Tinyburg",
+        sponsors: "Sponsors | Tinyburg",
+        developers: "Développeurs | Tinyburg",
+        developerApps: "Applications OAuth | Tinyburg",
+        towerMe: "Mes tours | Tinyburg",
+        towerLink: "Relie ta tour | Tinyburg",
+        account: "Compte et sécurité | Tinyburg",
+        notFound: "Page introuvable | Tinyburg",
+    },
+    home: {
+        nav: {
+            browseTrades: "Parcourir les échanges",
+            bitizens: "Bitizens",
+            costumes: "Costumes",
+            about: "À propos",
+        },
+        logIn: "Connexion",
+        heroTitle: "Échanges TinyTower",
+        heroTagline:
+            "La place de marché communautaire pour échanger bitizens, costumes, animaux et plus avec des joueurs de TinyTower du monde entier",
+        startTrading: "Commencer à échanger",
+        learnMore: "En savoir plus",
+        featuresHeading: "Que peux-tu échanger ?",
+        features: {
+            tradeBitizens: {
+                title: "Échange des bitizens",
+                description: "Trouve des bitizens à l'emploi de rêve pour ta tour ou échange tes doublons",
+            },
+            costumesPets: {
+                title: "Costumes et animaux",
+                description: "Collectionne des costumes rares et d'adorables animaux pour tes bitizens",
+            },
+            goldenTickets: {
+                title: "Tickets dorés",
+                description: "Échange des ressources et aide les autres bâtisseurs de tours",
+            },
+            community: {
+                title: "Communauté",
+                description: "Rejoins des milliers de joueurs actifs de TinyTower",
+            },
+        },
+        stats: {
+            activeTraders: "Joueurs actifs",
+            tradesCompleted: "Échanges réalisés",
+            bitizensTraded: "Bitizens échangés",
+        },
+        ctaHeading: "Prêt à bâtir la tour de tes rêves ?",
+        ctaBody: "Rejoins des milliers de joueurs qui échangent bitizens et objets chaque jour",
+        ctaButton: "Commencer gratuitement",
+        footerAbout: {
+            before: "Une plateforme d'échanges communautaire pour les passionnés de TinyTower. Sans affiliation avec NimbleBit. Le code source est disponible sur ",
+            linkLabel: "GitHub",
+            after: ".",
+        },
+        quickLinks: "Liens rapides",
+        community: "Communauté",
+        legal: "Mentions légales",
+        sponsors: "Sponsors",
+        privacyPolicy: "Politique de confidentialité",
+        termsOfService: "Conditions d'utilisation",
+        copyright: "© 2026 Tinyburg. TinyTower est une marque de NimbleBit LLC.",
+    },
+    about: {
+        title: "À propos de Tinyburg",
+        // REVIEW: tone-sensitive tagline.
+        tagline: "Créer des liens, un bitizen à la fois",
+        whatIsHeading: "Qu'est-ce que Tinyburg ?",
+        whatIsBody:
+            "Tinyburg est une plateforme d'échanges créée par la communauté des passionnés de TinyTower. On te facilite la recherche de bitizens à l'emploi de rêve, l'échange de costumes rares et la rencontre de bâtisseurs de tours du monde entier.",
+        missionHeading: "Notre mission",
+        missions: {
+            findDreamJobbers: {
+                title: "Trouve les employés de rêve",
+                description:
+                    "Arrête d'attendre des bitizens au hasard. Cherche dans notre base de données les bitizens parfaits à 9 points pour les emplois de rêve de tes étages.",
+            },
+            connectPlayers: {
+                title: "Relie les joueurs",
+                description:
+                    "Bâtir une tour est plus amusant à plusieurs. Rejoins des milliers de joueurs actifs prêts à échanger et à s'entraider.",
+            },
+            collectEverything: {
+                title: "Collectionne tout",
+                description: "Des costumes rares aux adorables animaux, échange jusqu'à compléter ta collection.",
+            },
+        },
+        howHeading: "Comment ça marche",
+        steps: {
+            signUp: {
+                title: "Inscris-toi",
+                description: "Crée ton compte avec Google ou Discord en quelques secondes",
+            },
+            linkTower: {
+                title: "Relie ta tour",
+                description: "Utilise la synchronisation cloud de Nimblebit pour relier ta tour",
+            },
+            browseTrade: {
+                title: "Parcours et échange",
+                description: "Trouve ce dont tu as besoin et entre en contact avec d'autres joueurs",
+            },
+            buildDream: {
+                title: "Bâtis la tour de tes rêves",
+                description: "Remplis chaque étage d'employés de rêve et d'objets rares",
+            },
+        },
+        communityHeading: "La communauté d'abord",
+        communityBody:
+            "Tinyburg est créé et entretenu par des joueurs passionnés de TinyTower. Nous ne sommes pas affiliés à NimbleBit, mais nous partageons leur amour des petits pixels et des grandes tours. Notre objectif : rendre la communauté TinyTower encore plus soudée et solidaire.",
+        joinDiscord: "Rejoins notre Discord",
+        openSourceHeading: "Open source",
+        openSourceBody:
+            "Tinyburg est un projet open source. Nous croyons à la transparence et aux contributions de la communauté. Consulte notre code, signale des bugs ou propose des fonctionnalités sur GitHub.",
+        viewOnGithub: "Voir sur GitHub",
+        ourSponsors: "Nos sponsors",
+        faqHeading: "Questions fréquentes",
+        faqs: {
+            free: {
+                question: "Q : Tinyburg est-il gratuit ?",
+                answer: "R : Oui ! Tinyburg est entièrement gratuit. Nous sommes un projet communautaire créé par des joueurs qui aiment le jeu.",
+            },
+            affiliated: {
+                question: "Q : Est-ce affilié à NimbleBit ?",
+                answer: "R : Non, Tinyburg est un projet de fans indépendant. Nous ne sommes ni affiliés, ni soutenus, ni liés à NimbleBit LLC de quelque manière que ce soit.",
+            },
+            trades: {
+                question: "Q : Comment fonctionnent les échanges ?",
+                answer: "R : Tinyburg t'aide à trouver des partenaires d'échange et à coordonner les transactions. L'échange lui-même peut passer par différentes méthodes selon les objets, comme l'envoi de cadeaux ou la modification des données de sauvegarde.",
+            },
+            dataSafe: {
+                question: "Mes données sont-elles en sécurité ?",
+                before: "Nous ne collectons que le nécessaire pour fournir le service. Consulte notre ",
+                linkLabel: "politique de confidentialité",
+                after: " pour tous les détails.",
+            },
+        },
+    },
+    login: {
+        heading: "Bienvenue sur Tinyburg",
+        subheading: "Connecte-toi ou crée un compte pour commencer",
+        problems: {
+            denied: "La connexion a été annulée. Tu peux reprendre où tu en étais quand tu veux.",
+            expired:
+                "Cette tentative de connexion a expiré ou a été interrompue. Recommence et vérifie que ton navigateur autorise les cookies pour ce site.",
+            failed: "Nous n'avons pas pu finaliser ta connexion. Réessaie.",
+        },
+        continueWithGoogle: "Continuer avec Google",
+        continueWithDiscord: "Continuer avec Discord",
+        perks: {
+            dreamJobs: "Trouve des bitizens à l'emploi de rêve",
+            trade: "Échange avec des milliers de joueurs",
+            collect: "Collectionne costumes rares et animaux",
+        },
+        agreeBefore: "En continuant, tu acceptes nos ",
+        termsOfService: "conditions d'utilisation",
+        agreeAnd: " et notre ",
+        privacyPolicy: "politique de confidentialité",
+    },
+    account: {
+        backToTowers: "← Retour à mes tours",
+        heading: (name) => `Compte de ${name}`,
+        notices: {
+            connected: "Connecté. Tu peux maintenant t'en servir pour te connecter.",
+            alreadyConnected: "Ce compte était déjà connecté.",
+            disconnected: "Déconnecté.",
+            linkCancelled: "La connexion de ce compte a été annulée.",
+        },
+        signedOutSessions: (count) => (count === 1 ? "1 session déconnectée." : `${count} sessions déconnectées.`),
+        problems: {
+            linkExpired: "Cette tentative a expiré ou a été interrompue. Réessaie de connecter le compte.",
+            linkFailed: "Nous n'avons pas pu connecter ce compte. Réessaie.",
+            accountTaken: "Ce compte est déjà connecté à un autre compte Tinyburg.",
+            actionFailed: "Ça n'a pas fonctionné. Réessaie.",
+            lastSignInMethod: "C'est ton seul moyen de te connecter, il doit donc rester connecté.",
+        },
+        loadFailed: "Nous n'avons pas pu charger ceci. Réessaie.",
+        sessionsHeading: "Où tu es connecté",
+        sessionsBody:
+            "Chaque navigateur détenant une session pour ce compte. Déconnecte tous ceux que tu ne reconnais pas.",
+        loadingSessions: "Chargement de tes sessions...",
+        unknownDevice: "Appareil inconnu",
+        deviceOn: (browser, platform) => `${browser} sur ${platform}`,
+        thisDevice: "Cet appareil",
+        lastActive: (when) => `Dernière activité : ${when}`,
+        signedInOn: (date) => `Connecté le ${date}`,
+        signOut: "Déconnecter",
+        signOutThisBrowser: "Se déconnecter de ce navigateur",
+        signOutOf: (name) => `Se déconnecter de ${name}`,
+        noOtherSessions: "Aucune autre session",
+        signOutOthers: (count) =>
+            count === 1 ? "Déconnecter 1 autre session" : `Déconnecter ${count} autres sessions`,
+        signOutEverywhere: "Se déconnecter partout",
+        methodsHeading: "Méthodes de connexion",
+        methodsBody: "Connecte d'autres moyens de te connecter, pour toujours pouvoir retrouver ce compte.",
+        loading: "Chargement...",
+        disconnect: "Dissocier",
+        disconnectProvider: (provider) => `Dissocier ${provider}`,
+        lastMethodTitle: "C'est le seul moyen de connexion qu'il te reste",
+        connect: "Connecter →",
+    },
+    developers: {
+        title: "Tinyburg pour les développeurs",
+        tagline: "Laisse les joueurs utiliser leur compte Tinyburg dans ton appli",
+        signInHeading: "Sign in with Tinyburg",
+        signInBody:
+            "Tinyburg est un fournisseur OpenID Connect. Tu construis un outil compagnon, un tableau de bord pour bot Discord ou autre chose pour la communauté TinyTower ? Enregistre une application OAuth et les joueurs pourront s'y connecter avec le compte qu'ils utilisent déjà pour échanger, sans nouveau mot de passe.",
+        features: {
+            standardOidc: {
+                title: "OIDC standard",
+                description:
+                    "Flux authorization code avec PKCE et jetons d'identité signés en ES256. Toute bibliothèque cliente OpenID Connect fonctionne directement.",
+            },
+            minimalScopes: {
+                title: "Scopes minimaux",
+                description:
+                    "Les applis ne voient que l'identité, le nom affiché et l'avatar du joueur. Rien d'autre ne quitte Tinyburg.",
+            },
+            playerConsent: {
+                title: "Consentement du joueur",
+                description:
+                    "Les joueurs approuvent exactement ce que ton appli peut voir sur un écran de consentement avant l'émission du moindre jeton.",
+            },
+        },
+        gettingStartedHeading: "Premiers pas",
+        steps: {
+            logIn: {
+                title: "Connecte-toi à Tinyburg",
+                description: "Il te faut un compte Tinyburg pour enregistrer des applications",
+            },
+            register: {
+                title: "Enregistre ton application",
+                description: "Donne-lui un nom et tes URIs de redirection, puis récupère ton client id et ton secret",
+            },
+            point: {
+                title: "Pointe ta bibliothèque OIDC vers nous",
+                description:
+                    "La plupart des bibliothèques n'ont besoin que de l'URL de discovery ci-dessous pour se configurer",
+            },
+            signIn: {
+                title: "Les joueurs se connectent",
+                description: "Ils approuvent ton appli une fois et reviennent sur ton URI de redirection",
+            },
+        },
+        redirectNote:
+            "Les URIs de redirection doivent utiliser https, sauf localhost pendant le développement. Les secrets client ne sont affichés qu'une fois à l'enregistrement et stockés hachés, alors garde le tien en lieu sûr.",
+        endpointsHeading: "Endpoints",
+        endpointsBody:
+            "Tout ce qui suit est aussi publié dans le document de discovery, la plupart des configurations n'ont donc besoin que de la première URL.",
+        endpointNames: {
+            jwks: "JWKS",
+            discovery: "Discovery",
+            authorization: "Autorisation",
+            token: "Jeton",
+            userinfo: "Userinfo",
+        },
+        scopesHeading: "Scopes",
+        scopeDescriptions: {
+            openid: "Confirmer ton identité Tinyburg",
+            profile: "Voir ton nom affiché et ton avatar",
+        },
+        readyHeading: "Prêt à construire ?",
+        readyBefore:
+            "Enregistre ta première application et commence à connecter des joueurs. Des questions ou un blocage ? Demande sur le ",
+        discordLinkLabel: "Discord Tinyburg",
+        readyAfter: " et nous t'aiderons.",
+        yourApplications: "Tes applications",
+        discoveryDocument: "Document de discovery",
+    },
+    developerApps: {
+        heading: "Applications OAuth",
+        comingSoon: "L'enregistrement en libre-service arrive",
+        comingSoonDetail:
+            "Sign in with Tinyburg fonctionne déjà. Demande sur le Discord et nous enregistrerons ton application à la main en attendant.",
+        readGuide: "← Lire le guide d'intégration",
+    },
+    sponsors: {
+        title: "Merci, sponsors !",
+        // REVIEW: figurative tagline.
+        tagline: "Celles et ceux qui laissent la lumière allumée à chaque étage",
+        intro: "Tinyburg est gratuit, open source et géré par des bénévoles. Les serveurs, la base de données et la caisse qui sécurise chaque échange sont payés par les personnes généreuses de cette page qui sponsorisent le projet sur GitHub. Chacune d'elles rend la tour un peu plus haute.",
+        becomeSponsor: "Devenir sponsor",
+        currentHeading: "Sponsors actuels",
+        noSponsors: "Pas encore de sponsors. Sois le premier bitizen de cet étage !",
+        pastHeading: "Anciens sponsors",
+        pastBody: "Sponsor un jour, apprécié toujours. Merci d'avoir aidé en chemin !",
+        otherWaysHeading: "D'autres façons d'aider",
+        otherWaysBody:
+            "Sponsoriser n'est pas la seule façon de soutenir Tinyburg. Signale des bugs, contribue une fonctionnalité ou viens simplement aider les autres bâtisseurs de tours de la communauté.",
+        starOnGithub: "Mettre une étoile sur GitHub",
+        joinDiscord: "Rejoins notre Discord",
+    },
+    towerLink: {
+        backToTowers: "← Mes tours",
+        heading: "Relie ta tour",
+        subheading: "Connecte ta sauvegarde cloud TinyTower pour commencer à échanger avec des joueurs du monde entier",
+        step1: "Étape 1 sur 2",
+        step2: "Étape 2 sur 2",
+        friendCodeLabel: "Code ami",
+        friendCodeTitle: "Jusqu'à 5 lettres ou chiffres",
+        friendCodeHint: "Tu le trouveras dans l'onglet Amis de TinyTower",
+        emailLabel: "E-mail de synchronisation cloud",
+        emailHint:
+            "L'adresse e-mail avec laquelle ta sauvegarde cloud est enregistrée. Nimblebit y enverra un code de vérification.",
+        sending: "Envoi...",
+        sendCode: "Envoyer le code de vérification",
+        sentCodeBefore: "📬 Nimblebit a envoyé un code de vérification à ",
+        sentCodeAfter: ". Il peut mettre une minute à arriver.",
+        codeLabel: "Code de vérification",
+        codeHint: "Pas d'e-mail ? Vérifie ton dossier spam",
+        linked: "Reliée ! Redirection...",
+        verifying: "Vérification...",
+        linkMyTower: "Relier ma tour",
+        goBack: "← Retour",
+        sent: "Envoyé !",
+        resend: "Renvoyer l'e-mail",
+        errors: {
+            requestFailed: "Nous n'avons pas pu joindre ta tour. Vérifie ton code ami et réessaie.",
+            verifyFailed: "Ce code n'a pas fonctionné. Vérifie-le et réessaie, ou renvoie l'e-mail.",
+            resendFailed: "Nous n'avons pas pu renvoyer l'e-mail. Réessaie dans un instant.",
+        },
+    },
+    towerMe: {
+        avatarAlt: (name) => `Avatar de ${name}`,
+        // REVIEW: playful title.
+        mayor: "🏙️ Maire de Tinyburg",
+        signOut: "Déconnexion",
+        towersHeading: "Mes tours",
+        linkATower: "+ Relier une tour",
+        noTowers: "Aucune tour reliée pour l'instant",
+        noTowersDetailLong:
+            "Relie ta sauvegarde TinyTower pour synchroniser tes bitizens et commencer à échanger avec des joueurs du monde entier.",
+        noTowersDetailShort: "Relie ta sauvegarde TinyTower pour commencer à échanger.",
+        loadingTowers: "Chargement de tes tours...",
+        towersLoadFailed: "Nous n'avons pas pu charger tes tours. Réessaie.",
+        linkedOn: (date) => `Reliée le ${date}`,
+        accountRow: {
+            title: "Compte et sécurité",
+            detail: "Gère où tu es connecté et comment tu te connectes",
+        },
+        developerRow: {
+            title: "Portail développeur",
+            detail: "Enregistre des applis OAuth qui connectent les utilisateurs avec Tinyburg",
+        },
+    },
+    notFound: {
+        heading: "Étage introuvable",
+        body: "Les bitizens ont peut-être déplacé cet étage ? Essaie plutôt le hall !",
+        goHome: "Retour à l'accueil",
+        goBack: "Page précédente",
+    },
+};

--- a/apps/tinyburg.app/client/messages/index.ts
+++ b/apps/tinyburg.app/client/messages/index.ts
@@ -1,0 +1,17 @@
+import type { Messages } from "./types.ts";
+import type { Language } from "@tinyburg/ui/Internationalization";
+
+import { de } from "./de.ts";
+import { en } from "./en.ts";
+import { es } from "./es.ts";
+import { fr } from "./fr.ts";
+
+const byLanguage: Record<Language, Messages> = { de, en, es, fr };
+
+/**
+ * The copy for a language. Reference-stable per language, which is what lets
+ * the lazy page wrappers memoize on the msgs slices they are handed.
+ */
+export const messagesFor = (language: Language): Messages => byLanguage[language];
+
+export * from "./types.ts";

--- a/apps/tinyburg.app/client/messages/types.ts
+++ b/apps/tinyburg.app/client/messages/types.ts
@@ -1,0 +1,308 @@
+/**
+ * Every piece of user-visible copy the SPA renders, one interface per page
+ * plus the document titles and the chrome shared between pages. Each locale
+ * module implements `Messages`, so a key missing from any translation is a
+ * compile error rather than a blank spot on the page.
+ *
+ * Interpolated strings are functions of their data; count-bearing strings are
+ * functions of the number so each language applies its own plural rules.
+ */
+
+/** Copy used by more than one page: back links and the tower floor labels. */
+export interface SharedMessages {
+    readonly back: string;
+    readonly backToHome: string;
+    readonly floors: {
+        readonly food: string;
+        readonly retail: string;
+        readonly service: string;
+        readonly creative: string;
+        readonly recreation: string;
+        readonly residential: string;
+        readonly lobby: string;
+    };
+}
+
+/** Document titles, one per route. */
+export interface TitleMessages {
+    readonly home: string;
+    readonly about: string;
+    readonly login: string;
+    readonly privacy: string;
+    readonly terms: string;
+    readonly sponsors: string;
+    readonly developers: string;
+    readonly developerApps: string;
+    readonly towerMe: string;
+    readonly towerLink: string;
+    readonly account: string;
+    readonly notFound: string;
+}
+
+export interface HomeMessages {
+    readonly nav: {
+        readonly browseTrades: string;
+        readonly bitizens: string;
+        readonly costumes: string;
+        readonly about: string;
+    };
+    readonly logIn: string;
+    readonly heroTitle: string;
+    readonly heroTagline: string;
+    readonly startTrading: string;
+    readonly learnMore: string;
+    readonly featuresHeading: string;
+    readonly features: {
+        readonly tradeBitizens: { readonly title: string; readonly description: string };
+        readonly costumesPets: { readonly title: string; readonly description: string };
+        readonly goldenTickets: { readonly title: string; readonly description: string };
+        readonly community: { readonly title: string; readonly description: string };
+    };
+    readonly stats: {
+        readonly activeTraders: string;
+        readonly tradesCompleted: string;
+        readonly bitizensTraded: string;
+    };
+    readonly ctaHeading: string;
+    readonly ctaBody: string;
+    readonly ctaButton: string;
+    readonly footerAbout: { readonly before: string; readonly linkLabel: string; readonly after: string };
+    readonly quickLinks: string;
+    readonly community: string;
+    readonly legal: string;
+    readonly sponsors: string;
+    readonly privacyPolicy: string;
+    readonly termsOfService: string;
+    readonly copyright: string;
+}
+
+export interface AboutMessages {
+    readonly title: string;
+    readonly tagline: string;
+    readonly whatIsHeading: string;
+    readonly whatIsBody: string;
+    readonly missionHeading: string;
+    readonly missions: {
+        readonly findDreamJobbers: { readonly title: string; readonly description: string };
+        readonly connectPlayers: { readonly title: string; readonly description: string };
+        readonly collectEverything: { readonly title: string; readonly description: string };
+    };
+    readonly howHeading: string;
+    readonly steps: {
+        readonly signUp: { readonly title: string; readonly description: string };
+        readonly linkTower: { readonly title: string; readonly description: string };
+        readonly browseTrade: { readonly title: string; readonly description: string };
+        readonly buildDream: { readonly title: string; readonly description: string };
+    };
+    readonly communityHeading: string;
+    readonly communityBody: string;
+    readonly joinDiscord: string;
+    readonly openSourceHeading: string;
+    readonly openSourceBody: string;
+    readonly viewOnGithub: string;
+    readonly ourSponsors: string;
+    readonly faqHeading: string;
+    readonly faqs: {
+        readonly free: { readonly question: string; readonly answer: string };
+        readonly affiliated: { readonly question: string; readonly answer: string };
+        readonly trades: { readonly question: string; readonly answer: string };
+        readonly dataSafe: {
+            readonly question: string;
+            readonly before: string;
+            readonly linkLabel: string;
+            readonly after: string;
+        };
+    };
+}
+
+export interface LoginMessages {
+    readonly heading: string;
+    readonly subheading: string;
+    readonly problems: {
+        readonly denied: string;
+        readonly expired: string;
+        readonly failed: string;
+    };
+    readonly continueWithGoogle: string;
+    readonly continueWithDiscord: string;
+    readonly perks: {
+        readonly dreamJobs: string;
+        readonly trade: string;
+        readonly collect: string;
+    };
+    readonly agreeBefore: string;
+    readonly termsOfService: string;
+    readonly agreeAnd: string;
+    readonly privacyPolicy: string;
+}
+
+export interface AccountMessages {
+    readonly backToTowers: string;
+    readonly heading: (name: string) => string;
+    readonly notices: {
+        readonly connected: string;
+        readonly alreadyConnected: string;
+        readonly disconnected: string;
+        readonly linkCancelled: string;
+    };
+    readonly signedOutSessions: (count: number) => string;
+    readonly problems: {
+        readonly linkExpired: string;
+        readonly linkFailed: string;
+        readonly accountTaken: string;
+        readonly actionFailed: string;
+        readonly lastSignInMethod: string;
+    };
+    readonly loadFailed: string;
+    readonly sessionsHeading: string;
+    readonly sessionsBody: string;
+    readonly loadingSessions: string;
+    readonly unknownDevice: string;
+    readonly deviceOn: (browser: string, platform: string) => string;
+    readonly thisDevice: string;
+    readonly lastActive: (when: string) => string;
+    readonly signedInOn: (date: string) => string;
+    readonly signOut: string;
+    readonly signOutThisBrowser: string;
+    readonly signOutOf: (name: string) => string;
+    readonly noOtherSessions: string;
+    readonly signOutOthers: (count: number) => string;
+    readonly signOutEverywhere: string;
+    readonly methodsHeading: string;
+    readonly methodsBody: string;
+    readonly loading: string;
+    readonly disconnect: string;
+    readonly disconnectProvider: (provider: string) => string;
+    readonly lastMethodTitle: string;
+    readonly connect: string;
+}
+
+export interface DevelopersMessages {
+    readonly title: string;
+    readonly tagline: string;
+    readonly signInHeading: string;
+    readonly signInBody: string;
+    readonly features: {
+        readonly standardOidc: { readonly title: string; readonly description: string };
+        readonly minimalScopes: { readonly title: string; readonly description: string };
+        readonly playerConsent: { readonly title: string; readonly description: string };
+    };
+    readonly gettingStartedHeading: string;
+    readonly steps: {
+        readonly logIn: { readonly title: string; readonly description: string };
+        readonly register: { readonly title: string; readonly description: string };
+        readonly point: { readonly title: string; readonly description: string };
+        readonly signIn: { readonly title: string; readonly description: string };
+    };
+    readonly redirectNote: string;
+    readonly endpointsHeading: string;
+    readonly endpointsBody: string;
+    readonly endpointNames: {
+        readonly jwks: string;
+        readonly discovery: string;
+        readonly authorization: string;
+        readonly token: string;
+        readonly userinfo: string;
+    };
+    readonly scopesHeading: string;
+    readonly scopeDescriptions: {
+        readonly openid: string;
+        readonly profile: string;
+    };
+    readonly readyHeading: string;
+    readonly readyBefore: string;
+    readonly discordLinkLabel: string;
+    readonly readyAfter: string;
+    readonly yourApplications: string;
+    readonly discoveryDocument: string;
+}
+
+export interface DeveloperAppsMessages {
+    readonly heading: string;
+    readonly comingSoon: string;
+    readonly comingSoonDetail: string;
+    readonly readGuide: string;
+}
+
+export interface SponsorsMessages {
+    readonly title: string;
+    readonly tagline: string;
+    readonly intro: string;
+    readonly becomeSponsor: string;
+    readonly currentHeading: string;
+    readonly noSponsors: string;
+    readonly pastHeading: string;
+    readonly pastBody: string;
+    readonly otherWaysHeading: string;
+    readonly otherWaysBody: string;
+    readonly starOnGithub: string;
+    readonly joinDiscord: string;
+}
+
+export interface TowerLinkMessages {
+    readonly backToTowers: string;
+    readonly heading: string;
+    readonly subheading: string;
+    readonly step1: string;
+    readonly step2: string;
+    readonly friendCodeLabel: string;
+    readonly friendCodeTitle: string;
+    readonly friendCodeHint: string;
+    readonly emailLabel: string;
+    readonly emailHint: string;
+    readonly sending: string;
+    readonly sendCode: string;
+    readonly sentCodeBefore: string;
+    readonly sentCodeAfter: string;
+    readonly codeLabel: string;
+    readonly codeHint: string;
+    readonly linked: string;
+    readonly verifying: string;
+    readonly linkMyTower: string;
+    readonly goBack: string;
+    readonly sent: string;
+    readonly resend: string;
+    readonly errors: {
+        readonly requestFailed: string;
+        readonly verifyFailed: string;
+        readonly resendFailed: string;
+    };
+}
+
+export interface TowerMeMessages {
+    readonly avatarAlt: (name: string) => string;
+    readonly mayor: string;
+    readonly signOut: string;
+    readonly towersHeading: string;
+    readonly linkATower: string;
+    readonly noTowers: string;
+    readonly noTowersDetailLong: string;
+    readonly noTowersDetailShort: string;
+    readonly loadingTowers: string;
+    readonly towersLoadFailed: string;
+    readonly linkedOn: (date: string) => string;
+    readonly accountRow: { readonly title: string; readonly detail: string };
+    readonly developerRow: { readonly title: string; readonly detail: string };
+}
+
+export interface NotFoundMessages {
+    readonly heading: string;
+    readonly body: string;
+    readonly goHome: string;
+    readonly goBack: string;
+}
+
+export interface Messages {
+    readonly shared: SharedMessages;
+    readonly titles: TitleMessages;
+    readonly home: HomeMessages;
+    readonly about: AboutMessages;
+    readonly login: LoginMessages;
+    readonly account: AccountMessages;
+    readonly developers: DevelopersMessages;
+    readonly developerApps: DeveloperAppsMessages;
+    readonly sponsors: SponsorsMessages;
+    readonly towerLink: TowerLinkMessages;
+    readonly towerMe: TowerMeMessages;
+    readonly notFound: NotFoundMessages;
+}

--- a/apps/tinyburg.app/client/pages/about.ts
+++ b/apps/tinyburg.app/client/pages/about.ts
@@ -1,3 +1,4 @@
+import type { AboutMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { articleBackLink, articleHeading } from "../ui/chrome.ts";
@@ -53,11 +54,11 @@ const faq = <M>(h: HtmlBuilder<M>, question: string, answer: ReadonlyArray<Html 
         ]
     );
 
-export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
+export const aboutView = <M>(h: HtmlBuilder<M>, msgs: AboutMessages, shared: SharedMessages): Html =>
     h.div(
         [h.Class("relative min-h-screen px-4 py-16 sm:px-8 sm:py-20")],
         [
-            articleBackLink(h, "/", "Back"),
+            articleBackLink(h, "/", shared.back),
             h.article(
                 [h.Class("mx-auto max-w-3xl")],
                 [
@@ -75,12 +76,9 @@ export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
                                         "font-pixel text-dark-blue mb-2 text-base leading-relaxed sm:text-lg md:text-xl"
                                     ),
                                 ],
-                                ["About Tinyburg"]
+                                [msgs.title]
                             ),
-                            h.p(
-                                [h.Class("text-text-dark/80 text-xl")],
-                                ["Building connections, one bitizen at a time"]
-                            ),
+                            h.p([h.Class("text-text-dark/80 text-xl")], [msgs.tagline]),
                         ]
                     ),
                     h.div(
@@ -92,37 +90,32 @@ export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
                         [
                             h.section(
                                 [h.Class("pb-8")],
-                                [
-                                    articleHeading(h, "What is Tinyburg?"),
-                                    para(h, [
-                                        "Tinyburg is a community-made trading platform built by TinyTower enthusiasts. We make it easy to find dream job bitizens, trade rare costumes, and connect with fellow tower builders from around the world.",
-                                    ]),
-                                ]
+                                [articleHeading(h, msgs.whatIsHeading), para(h, [msgs.whatIsBody])]
                             ),
                             h.section(
                                 [h.Class("py-8")],
                                 [
-                                    articleHeading(h, "Our Mission"),
+                                    articleHeading(h, msgs.missionHeading),
                                     h.div(
                                         [h.Class("mt-4 grid grid-cols-1 gap-6 md:grid-cols-3")],
                                         [
                                             missionCard(
                                                 h,
                                                 "🎯",
-                                                "Find Dream Jobbers",
-                                                "Stop waiting for random bitizens. Search our database to find the perfect 9-skill dream jobbers for your floors."
+                                                msgs.missions.findDreamJobbers.title,
+                                                msgs.missions.findDreamJobbers.description
                                             ),
                                             missionCard(
                                                 h,
                                                 "🤝",
-                                                "Connect Players",
-                                                "Building a tower is more fun together. Connect with thousands of active players ready to trade and help each other out."
+                                                msgs.missions.connectPlayers.title,
+                                                msgs.missions.connectPlayers.description
                                             ),
                                             missionCard(
                                                 h,
                                                 "🎨",
-                                                "Collect Everything",
-                                                "From rare costumes to adorable pets, trade your way to completing your collection."
+                                                msgs.missions.collectEverything.title,
+                                                msgs.missions.collectEverything.description
                                             ),
                                         ]
                                     ),
@@ -131,34 +124,19 @@ export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
                             h.section(
                                 [h.Class("py-8")],
                                 [
-                                    articleHeading(h, "How It Works"),
+                                    articleHeading(h, msgs.howHeading),
                                     h.div(
                                         [h.Class("mt-4 flex flex-col gap-4")],
                                         [
-                                            step(
-                                                h,
-                                                1,
-                                                "Sign Up",
-                                                "Create your account using Google or Discord in seconds"
-                                            ),
-                                            step(
-                                                h,
-                                                2,
-                                                "Link Your Tower",
-                                                "Use Nimblebit's cloud sync feature to link your tower"
-                                            ),
+                                            step(h, 1, msgs.steps.signUp.title, msgs.steps.signUp.description),
+                                            step(h, 2, msgs.steps.linkTower.title, msgs.steps.linkTower.description),
                                             step(
                                                 h,
                                                 3,
-                                                "Browse & Trade",
-                                                "Find what you need and connect with other players"
+                                                msgs.steps.browseTrade.title,
+                                                msgs.steps.browseTrade.description
                                             ),
-                                            step(
-                                                h,
-                                                4,
-                                                "Build Your Dream Tower",
-                                                "Fill every floor with dream jobbers and rare items"
-                                            ),
+                                            step(h, 4, msgs.steps.buildDream.title, msgs.steps.buildDream.description),
                                         ]
                                     ),
                                 ]
@@ -166,10 +144,8 @@ export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
                             h.section(
                                 [h.Class("py-8")],
                                 [
-                                    articleHeading(h, "Community First"),
-                                    para(h, [
-                                        "Tinyburg is built and maintained by passionate TinyTower players. We're not affiliated with NimbleBit, but we share their love for tiny pixels and tall towers. Our goal is to make the TinyTower community even more connected and helpful.",
-                                    ]),
+                                    articleHeading(h, msgs.communityHeading),
+                                    para(h, [msgs.communityBody]),
                                     h.div(
                                         [h.Class("mt-6 flex flex-col gap-4 md:flex-row")],
                                         [
@@ -180,7 +156,7 @@ export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
                                                         "bg-discord shadow-pixel hover:shadow-pixel-hover flex items-center justify-center gap-2 rounded-lg px-5 py-3 text-lg text-white transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                                     ),
                                                 ],
-                                                [h.span([], ["💬"]), " Join our Discord"]
+                                                [h.span([], ["💬"]), ` ${msgs.joinDiscord}`]
                                             ),
                                             h.a(
                                                 [
@@ -200,10 +176,8 @@ export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
                             h.section(
                                 [h.Class("py-8")],
                                 [
-                                    articleHeading(h, "Open Source"),
-                                    para(h, [
-                                        "Tinyburg is an open source project. We believe in transparency and community contribution. Check out our code, report bugs, or contribute features on GitHub.",
-                                    ]),
+                                    articleHeading(h, msgs.openSourceHeading),
+                                    para(h, [msgs.openSourceBody]),
                                     h.div(
                                         [h.Class("mt-2 flex flex-col gap-4 md:flex-row")],
                                         [
@@ -216,7 +190,7 @@ export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
                                                         "shadow-pixel hover:shadow-pixel-hover flex items-center justify-center gap-2 rounded-lg bg-[#24292e] px-5 py-3 text-lg text-white transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-[#1a1e22]"
                                                     ),
                                                 ],
-                                                [githubIcon(h, "h-5 w-5"), " View on GitHub"]
+                                                [githubIcon(h, "h-5 w-5"), ` ${msgs.viewOnGithub}`]
                                             ),
                                             h.a(
                                                 [
@@ -225,7 +199,7 @@ export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
                                                         "shadow-pixel hover:shadow-pixel-hover flex items-center justify-center gap-2 rounded-lg bg-[#ea4aaa] px-5 py-3 text-lg text-white transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-[#d43a99]"
                                                     ),
                                                 ],
-                                                [h.span([], ["💖"]), " Our Sponsors"]
+                                                [h.span([], ["💖"]), ` ${msgs.ourSponsors}`]
                                             ),
                                         ]
                                     ),
@@ -234,36 +208,15 @@ export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
                             h.section(
                                 [h.Class("pt-8")],
                                 [
-                                    articleHeading(h, "Frequently Asked Questions"),
+                                    articleHeading(h, msgs.faqHeading),
+                                    faq(h, msgs.faqs.free.question, [msgs.faqs.free.answer], false),
+                                    faq(h, msgs.faqs.affiliated.question, [msgs.faqs.affiliated.answer], false),
+                                    faq(h, msgs.faqs.trades.question, [msgs.faqs.trades.answer], false),
                                     faq(
                                         h,
-                                        "Q: Is Tinyburg free?",
+                                        msgs.faqs.dataSafe.question,
                                         [
-                                            "A: Yes! Tinyburg is completely free to use. We're a community project built by players who love the game.",
-                                        ],
-                                        false
-                                    ),
-                                    faq(
-                                        h,
-                                        "Q: Is this affiliated with NimbleBit?",
-                                        [
-                                            "A: No, Tinyburg is an independent fan project. We're not affiliated with, endorsed by, or connected to NimbleBit LLC in any way.",
-                                        ],
-                                        false
-                                    ),
-                                    faq(
-                                        h,
-                                        "Q: How do trades work?",
-                                        [
-                                            "A: Tinyburg helps you find traders and coordinate exchanges. The actual trading can leverage a couple different methods to exchange the items depending on what the items are, such as sending gifts or modifying save data.",
-                                        ],
-                                        false
-                                    ),
-                                    faq(
-                                        h,
-                                        "Is my data safe?",
-                                        [
-                                            "We only collect what's necessary to provide the service. Check our ",
+                                            msgs.faqs.dataSafe.before,
                                             h.a(
                                                 [
                                                     h.Href("/privacy"),
@@ -271,9 +224,9 @@ export const aboutView = <M>(h: HtmlBuilder<M>): Html =>
                                                         "text-sky-dark decoration-sky-dark/30 hover:decoration-sky-dark underline decoration-2 underline-offset-2 transition-colors"
                                                     ),
                                                 ],
-                                                ["Privacy Policy"]
+                                                [msgs.faqs.dataSafe.linkLabel]
                                             ),
-                                            " for full details.",
+                                            msgs.faqs.dataSafe.after,
                                         ],
                                         true
                                     ),

--- a/apps/tinyburg.app/client/pages/account.ts
+++ b/apps/tinyburg.app/client/pages/account.ts
@@ -1,8 +1,10 @@
 import { DateTime, Effect, Match, Option, Result, Schema as S } from "effect";
 
 import type { Message as AppMessage } from "../main.ts";
+import type { AccountMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
+import { type Language, longDate, relativeTime } from "@tinyburg/ui/Internationalization";
 import { AsyncData, Command } from "foldkit";
 import { m } from "foldkit/message";
 import { evo } from "foldkit/struct";
@@ -28,8 +30,30 @@ type SessionSummary = typeof SessionSummary.Type;
 
 // MODEL
 
-export const Sessions = AsyncData.Schema(S.Array(SessionSummary), S.String);
-export const LinkedAccounts = AsyncData.Schema(S.Array(OAuthAccount.json), S.String);
+/**
+ * What the page has to say about itself is stored as keys (plus any data the
+ * phrasing needs) rather than finished sentences: commands and update run
+ * without knowing the language, so only the view turns these into copy.
+ */
+export const AccountNotice = S.Union([
+    S.Literals(["connected", "alreadyConnected", "disconnected", "linkCancelled"]),
+    S.Struct({ revoked: S.Number }),
+]);
+export type AccountNotice = typeof AccountNotice.Type;
+
+export const AccountProblem = S.Literals([
+    "linkExpired",
+    "linkFailed",
+    "accountTaken",
+    "actionFailed",
+    "lastSignInMethod",
+]);
+export type AccountProblem = typeof AccountProblem.Type;
+
+const LoadFailed = S.Literals(["loadFailed"]);
+
+export const Sessions = AsyncData.Schema(S.Array(SessionSummary), LoadFailed);
+export const LinkedAccounts = AsyncData.Schema(S.Array(OAuthAccount.json), LoadFailed);
 
 export const AccountModel = S.Struct({
     sessions: Sessions.schema,
@@ -42,8 +66,8 @@ export const AccountModel = S.Struct({
 
     // The row currently mid-request, so only its own button says so.
     busy: S.Option(S.String),
-    notice: S.Option(S.String),
-    problem: S.Option(S.String),
+    notice: S.Option(AccountNotice),
+    problem: S.Option(AccountProblem),
 });
 export type AccountModel = typeof AccountModel.Type;
 
@@ -75,17 +99,9 @@ export const enterAccount = (
     if (Option.isSome(error)) {
         return Match.value(classifyOAuthError(error.value)).pipe(
             Match.withReturnType<AccountModel>(),
-            Match.when("denied", () =>
-                evo(entered, { notice: () => Option.some("Connecting that account was cancelled.") })
-            ),
-            Match.when("expired", () =>
-                evo(entered, {
-                    problem: () => Option.some("That attempt expired or was interrupted. Please try connecting again."),
-                })
-            ),
-            Match.when("failed", () =>
-                evo(entered, { problem: () => Option.some("We couldn't connect that account. Please try again.") })
-            ),
+            Match.when("denied", () => evo(entered, { notice: () => Option.some("linkCancelled" as const) })),
+            Match.when("expired", () => evo(entered, { problem: () => Option.some("linkExpired" as const) })),
+            Match.when("failed", () => evo(entered, { problem: () => Option.some("linkFailed" as const) })),
             Match.exhaustive
         );
     }
@@ -95,18 +111,11 @@ export const enterAccount = (
         onSome: (outcome) =>
             Match.value(outcome).pipe(
                 Match.withReturnType<AccountModel>(),
-                Match.when("linked", () =>
-                    evo(entered, { notice: () => Option.some("Connected. You can now sign in with it.") })
-                ),
+                Match.when("linked", () => evo(entered, { notice: () => Option.some("connected" as const) })),
                 Match.when("alreadyLinked", () =>
-                    evo(entered, { notice: () => Option.some("That account was already connected.") })
+                    evo(entered, { notice: () => Option.some("alreadyConnected" as const) })
                 ),
-                Match.when("taken", () =>
-                    evo(entered, {
-                        problem: () =>
-                            Option.some("That account is already connected to a different Tinyburg account."),
-                    })
-                ),
+                Match.when("taken", () => evo(entered, { problem: () => Option.some("accountTaken" as const) })),
                 Match.orElse(() => entered)
             ),
     });
@@ -117,11 +126,11 @@ export const enterAccount = (
 // Fetches settle into a Result; update folds it into the current state with
 // `AsyncData.settle`, which keeps held data as Stale on failure.
 export const SettledSessions = m("SettledSessions", {
-    result: S.Result(S.Array(SessionSummary), S.String),
+    result: S.Result(S.Array(SessionSummary), LoadFailed),
     asOf: S.DateTimeUtc,
 });
 export const SettledLinkedAccounts = m("SettledLinkedAccounts", {
-    result: S.Result(S.Array(OAuthAccount.json), S.String),
+    result: S.Result(S.Array(OAuthAccount.json), LoadFailed),
 });
 export const ClickedRevokeSession = m("ClickedRevokeSession", { sessionId: S.String });
 export const ClickedRevokeOthers = m("ClickedRevokeOthers");
@@ -132,7 +141,7 @@ export const ClickedUnlink = m("ClickedUnlink", {
 });
 export const CompletedRevoke = m("CompletedRevoke", { revoked: S.Number, signedOut: S.Boolean });
 export const CompletedUnlink = m("CompletedUnlink");
-export const FailedAction = m("FailedAction", { message: S.String });
+export const FailedAction = m("FailedAction", { problem: AccountProblem });
 
 /** The session ended somewhere else while this page was open. */
 export const SignedOutElsewhere = m("SignedOutElsewhere");
@@ -153,9 +162,6 @@ export type AccountMessage = typeof AccountMessage.Type;
 
 // COMMAND
 
-const LOAD_FAILED = "We couldn't load this. Please try again.";
-const ACTION_FAILED = "That didn't work. Please try again.";
-
 export const FetchSessions = Command.define("FetchSessions", {
     messages: [SettledSessions, SignedOutElsewhere],
     execute: Effect.gen(function* () {
@@ -165,7 +171,7 @@ export const FetchSessions = Command.define("FetchSessions", {
     }).pipe(
         Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
         Effect.catch(() =>
-            Effect.map(DateTime.now, (asOf) => SettledSessions({ result: Result.fail(LOAD_FAILED), asOf }))
+            Effect.map(DateTime.now, (asOf) => SettledSessions({ result: Result.fail("loadFailed"), asOf }))
         )
     ),
 });
@@ -178,7 +184,7 @@ export const FetchLinkedAccounts = Command.define("FetchLinkedAccounts", {
         return SettledLinkedAccounts({ result: Result.succeed(accounts) });
     }).pipe(
         Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-        Effect.catch(() => Effect.succeed(SettledLinkedAccounts({ result: Result.fail(LOAD_FAILED) })))
+        Effect.catch(() => Effect.succeed(SettledLinkedAccounts({ result: Result.fail("loadFailed") })))
     ),
 });
 
@@ -191,7 +197,7 @@ export const RevokeSession = Command.define("RevokeSession", {
             return CompletedRevoke(yield* auth.AuthGroup.revokeSession({ params: { sessionId } }));
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-            Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+            Effect.catch(() => Effect.succeed(FailedAction({ problem: "actionFailed" })))
         ),
 });
 
@@ -202,7 +208,7 @@ export const RevokeOthers = Command.define("RevokeOthers", {
         return CompletedRevoke(yield* auth.AuthGroup.revokeSessions({ query: { scope: "others" } }));
     }).pipe(
         Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-        Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+        Effect.catch(() => Effect.succeed(FailedAction({ problem: "actionFailed" })))
     ),
 });
 
@@ -213,7 +219,7 @@ export const RevokeAll = Command.define("RevokeAll", {
         return CompletedRevoke(yield* auth.AuthGroup.revokeSessions({ query: { scope: "all" } }));
     }).pipe(
         Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-        Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+        Effect.catch(() => Effect.succeed(FailedAction({ problem: "actionFailed" })))
     ),
 });
 
@@ -229,12 +235,8 @@ export const Unlink = Command.define("Unlink", {
             Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
             // The server refuses to remove the last way in; the button is
             // disabled for it, but a stale page can still ask.
-            Effect.catchTag("Conflict", () =>
-                Effect.succeed(
-                    FailedAction({ message: "That's your only way to sign in, so it has to stay connected." })
-                )
-            ),
-            Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+            Effect.catchTag("Conflict", () => Effect.succeed(FailedAction({ problem: "lastSignInMethod" }))),
+            Effect.catch(() => Effect.succeed(FailedAction({ problem: "actionFailed" })))
         ),
 });
 
@@ -274,10 +276,7 @@ export const updateAccount = (model: AccountModel, message: AccountMessage): Acc
                     : [
                           evo(model, {
                               busy: Option.none,
-                              notice: () =>
-                                  Option.some(
-                                      revoked === 1 ? "Signed out of 1 session." : `Signed out of ${revoked} sessions.`
-                                  ),
+                              notice: () => Option.some({ revoked }),
                               sessions: (sessions) => Option.getOrElse(AsyncData.revalidate(sessions), () => sessions),
                           }),
                           [FetchSessions()],
@@ -286,13 +285,13 @@ export const updateAccount = (model: AccountModel, message: AccountMessage): Acc
             CompletedUnlink: () => [
                 evo(model, {
                     busy: Option.none,
-                    notice: () => Option.some("Disconnected."),
+                    notice: () => Option.some("disconnected" as const),
                     accounts: (accounts) => Option.getOrElse(AsyncData.revalidate(accounts), () => accounts),
                 }),
                 [FetchLinkedAccounts()],
             ],
 
-            FailedAction: ({ message }) => [evo(model, { busy: Option.none, problem: () => Option.some(message) }), []],
+            FailedAction: ({ problem }) => [evo(model, { busy: Option.none, problem: () => Option.some(problem) }), []],
 
             SignedOutElsewhere: () => [evo(model, { busy: Option.none }), []],
         })
@@ -313,7 +312,7 @@ const quietButton =
  * visitor actually recognises a session by. Anything unfamiliar keeps its raw
  * string rather than being guessed at and named wrongly.
  */
-const describeUserAgent = (userAgent: string): string => {
+const describeUserAgent = (msgs: AccountMessages, userAgent: string): string => {
     const browser = /\bEdg\//.test(userAgent)
         ? "Edge"
         : /\bOPR\/|\bOpera\b/.test(userAgent)
@@ -340,24 +339,8 @@ const describeUserAgent = (userAgent: string): string => {
                   ? "Linux"
                   : undefined;
 
-    if (browser !== undefined && platform !== undefined) return `${browser} on ${platform}`;
+    if (browser !== undefined && platform !== undefined) return msgs.deviceOn(browser, platform);
     return browser ?? platform ?? userAgent;
-};
-
-const relative = (asOf: DateTime.Utc, when: DateTime.Utc): string => {
-    const seconds = Math.round((DateTime.toEpochMillis(asOf) - DateTime.toEpochMillis(when)) / 1000);
-    if (seconds < 90) return "just now";
-
-    const minutes = Math.round(seconds / 60);
-    if (minutes < 60) return `${minutes} minutes ago`;
-
-    const hours = Math.round(minutes / 60);
-    if (hours < 24) return hours === 1 ? "an hour ago" : `${hours} hours ago`;
-
-    const days = Math.round(hours / 24);
-    if (days < 30) return days === 1 ? "yesterday" : `${days} days ago`;
-
-    return DateTime.format(when, { locale: "en-US", month: "long", day: "numeric", year: "numeric" });
 };
 
 const banner = (h: HtmlBuilder<AppMessage>, tone: "notice" | "problem", text: string): Html =>
@@ -373,11 +356,17 @@ const banner = (h: HtmlBuilder<AppMessage>, tone: "notice" | "problem", text: st
         [text]
     );
 
-const sessionRow = (h: HtmlBuilder<AppMessage>, session: SessionSummary, model: AccountModel): Html => {
+const sessionRow = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: AccountMessages,
+    language: Language,
+    session: SessionSummary,
+    model: AccountModel
+): Html => {
     const busy = Option.contains(model.busy, session.id);
     const name = Option.match(session.userAgent, {
-        onSome: describeUserAgent,
-        onNone: () => "Unknown device",
+        onSome: (userAgent) => describeUserAgent(msgs, userAgent),
+        onNone: () => msgs.unknownDevice,
     });
 
     return h.keyed("div")(
@@ -400,7 +389,7 @@ const sessionRow = (h: HtmlBuilder<AppMessage>, session: SessionSummary, model: 
                             session.current
                                 ? h.span(
                                       [h.Class("font-pixel bg-sky-dark rounded px-2 py-1 text-[0.5rem] text-white")],
-                                      ["This device"]
+                                      [msgs.thisDevice]
                                   )
                                 : h.empty,
                         ]
@@ -408,7 +397,7 @@ const sessionRow = (h: HtmlBuilder<AppMessage>, session: SessionSummary, model: 
                     h.div(
                         [h.Class("font-mono text-base text-gray-500")],
                         [
-                            `Last active ${relative(model.asOf, session.lastSeenAt)}`,
+                            msgs.lastActive(relativeTime(language, model.asOf, session.lastSeenAt)),
                             ...Option.match(session.ip, {
                                 onSome: (ip) => [` · ${ip}`],
                                 onNone: () => [],
@@ -417,14 +406,7 @@ const sessionRow = (h: HtmlBuilder<AppMessage>, session: SessionSummary, model: 
                     ),
                     h.div(
                         [h.Class("font-mono text-base text-gray-500")],
-                        [
-                            `Signed in ${DateTime.format(session.createdAt, {
-                                locale: "en-US",
-                                month: "long",
-                                day: "numeric",
-                                year: "numeric",
-                            })}`,
-                        ]
+                        [msgs.signedInOn(longDate(language, session.createdAt))]
                     ),
                 ]
             ),
@@ -433,23 +415,28 @@ const sessionRow = (h: HtmlBuilder<AppMessage>, session: SessionSummary, model: 
                     h.Type("button"),
                     h.Class(dangerButton),
                     h.Disabled(busy),
-                    h.Title(session.current ? "Sign out of this browser" : `Sign out of ${name}`),
+                    h.Title(session.current ? msgs.signOutThisBrowser : msgs.signOutOf(name)),
                     h.OnClick(ClickedRevokeSession({ sessionId: session.id })),
                 ],
-                [busy ? "..." : "Sign out"]
+                [busy ? "..." : msgs.signOut]
             ),
         ]
     );
 };
 
-const sessionsSection = (h: HtmlBuilder<AppMessage>, model: AccountModel): Html => {
+const sessionsSection = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: AccountMessages,
+    language: Language,
+    model: AccountModel
+): Html => {
     const list = (sessions: ReadonlyArray<SessionSummary>): Html => {
         const others = sessions.filter((session) => !session.current).length;
 
         return h.div(
             [h.Class("flex flex-col gap-4")],
             [
-                ...sessions.map((session) => sessionRow(h, session, model)),
+                ...sessions.map((session) => sessionRow(h, msgs, language, session, model)),
                 h.div(
                     [h.Class("flex flex-wrap gap-3 pt-2")],
                     [
@@ -460,13 +447,7 @@ const sessionsSection = (h: HtmlBuilder<AppMessage>, model: AccountModel): Html 
                                 h.Disabled(others === 0 || Option.isSome(model.busy)),
                                 h.OnClick(ClickedRevokeOthers()),
                             ],
-                            [
-                                others === 0
-                                    ? "No other sessions"
-                                    : others === 1
-                                      ? "Sign out 1 other session"
-                                      : `Sign out ${others} other sessions`,
-                            ]
+                            [others === 0 ? msgs.noOtherSessions : msgs.signOutOthers(others)]
                         ),
                         h.button(
                             [
@@ -475,7 +456,7 @@ const sessionsSection = (h: HtmlBuilder<AppMessage>, model: AccountModel): Html 
                                 h.Disabled(Option.isSome(model.busy)),
                                 h.OnClick(ClickedRevokeAll()),
                             ],
-                            ["Sign out everywhere"]
+                            [msgs.signOutEverywhere]
                         ),
                     ]
                 ),
@@ -486,15 +467,12 @@ const sessionsSection = (h: HtmlBuilder<AppMessage>, model: AccountModel): Html 
     return h.section(
         [h.Class(card)],
         [
-            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], ["Where You're Signed In"]),
-            h.p(
-                [h.Class("font-mono mb-6 text-lg text-gray-500")],
-                ["Every browser holding a session for this account. Sign out of any you don't recognise."]
-            ),
+            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], [msgs.sessionsHeading]),
+            h.p([h.Class("font-mono mb-6 text-lg text-gray-500")], [msgs.sessionsBody]),
             AsyncData.match(model.sessions, {
-                onIdle: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading your sessions..."]),
-                onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading your sessions..."]),
-                onFailure: (error) => h.p([h.Class("font-mono text-xl text-red-700")], [error]),
+                onIdle: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loadingSessions]),
+                onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loadingSessions]),
+                onFailure: () => h.p([h.Class("font-mono text-xl text-red-700")], [msgs.loadFailed]),
                 onRefreshing: list,
                 onStale: ({ data }) => list(data),
                 onSuccess: list,
@@ -511,7 +489,13 @@ const providerIcon = (h: HtmlBuilder<AppMessage>, provider: OAuthProviderName): 
 
 const providerLabel = (provider: OAuthProviderName): string => (provider === "discord" ? "Discord" : "Google");
 
-const linkedRow = (h: HtmlBuilder<AppMessage>, account: LinkedAccount, model: AccountModel, last: boolean): Html => {
+const linkedRow = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: AccountMessages,
+    account: LinkedAccount,
+    model: AccountModel,
+    last: boolean
+): Html => {
     const busy = Option.contains(model.busy, account.providerAccountId);
     const detail = Option.orElse(account.email, () => account.displayName);
 
@@ -539,11 +523,7 @@ const linkedRow = (h: HtmlBuilder<AppMessage>, account: LinkedAccount, model: Ac
                     h.Type("button"),
                     h.Class(dangerButton),
                     h.Disabled(busy || last),
-                    h.Title(
-                        last
-                            ? "This is the only way you have left to sign in"
-                            : `Disconnect ${providerLabel(account.provider)}`
-                    ),
+                    h.Title(last ? msgs.lastMethodTitle : msgs.disconnectProvider(providerLabel(account.provider))),
                     h.OnClick(
                         ClickedUnlink({
                             provider: account.provider,
@@ -551,13 +531,13 @@ const linkedRow = (h: HtmlBuilder<AppMessage>, account: LinkedAccount, model: Ac
                         })
                     ),
                 ],
-                [busy ? "..." : "Disconnect"]
+                [busy ? "..." : msgs.disconnect]
             ),
         ]
     );
 };
 
-const connectRow = (h: HtmlBuilder<AppMessage>, provider: OAuthProviderName): Html =>
+const connectRow = (h: HtmlBuilder<AppMessage>, msgs: AccountMessages, provider: OAuthProviderName): Html =>
     h.a(
         [
             h.Href(linkHref(provider)),
@@ -568,13 +548,13 @@ const connectRow = (h: HtmlBuilder<AppMessage>, provider: OAuthProviderName): Ht
         [
             providerIcon(h, provider),
             h.span([h.Class("font-mono text-xl text-gray-800")], [providerLabel(provider)]),
-            h.span([h.Class("font-pixel ml-auto shrink-0 text-[0.6rem] text-gray-500")], ["Connect →"]),
+            h.span([h.Class("font-pixel ml-auto shrink-0 text-[0.6rem] text-gray-500")], [msgs.connect]),
         ]
     );
 
 const ALL_PROVIDERS: ReadonlyArray<OAuthProviderName> = ["google", "discord"];
 
-const accountsSection = (h: HtmlBuilder<AppMessage>, model: AccountModel): Html => {
+const accountsSection = (h: HtmlBuilder<AppMessage>, msgs: AccountMessages, model: AccountModel): Html => {
     const list = (accounts: ReadonlyArray<LinkedAccount>): Html => {
         const linked = new Set(accounts.map((account) => account.provider));
         const unlinked = ALL_PROVIDERS.filter((provider) => !linked.has(provider));
@@ -582,8 +562,8 @@ const accountsSection = (h: HtmlBuilder<AppMessage>, model: AccountModel): Html 
         return h.div(
             [h.Class("flex flex-col gap-4")],
             [
-                ...accounts.map((account) => linkedRow(h, account, model, accounts.length === 1)),
-                ...unlinked.map((provider) => connectRow(h, provider)),
+                ...accounts.map((account) => linkedRow(h, msgs, account, model, accounts.length === 1)),
+                ...unlinked.map((provider) => connectRow(h, msgs, provider)),
             ]
         );
     };
@@ -591,15 +571,12 @@ const accountsSection = (h: HtmlBuilder<AppMessage>, model: AccountModel): Html 
     return h.section(
         [h.Class(card)],
         [
-            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], ["Sign-In Methods"]),
-            h.p(
-                [h.Class("font-mono mb-6 text-lg text-gray-500")],
-                ["Connect more ways to sign in, so you can always get back to this account."]
-            ),
+            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], [msgs.methodsHeading]),
+            h.p([h.Class("font-mono mb-6 text-lg text-gray-500")], [msgs.methodsBody]),
             AsyncData.match(model.accounts, {
-                onIdle: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading..."]),
-                onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading..."]),
-                onFailure: (error) => h.p([h.Class("font-mono text-xl text-red-700")], [error]),
+                onIdle: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loading]),
+                onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loading]),
+                onFailure: () => h.p([h.Class("font-mono text-xl text-red-700")], [msgs.loadFailed]),
                 onRefreshing: list,
                 onStale: ({ data }) => list(data),
                 onSuccess: list,
@@ -608,25 +585,35 @@ const accountsSection = (h: HtmlBuilder<AppMessage>, model: AccountModel): Html 
     );
 };
 
-export const accountView = (h: HtmlBuilder<AppMessage>, model: AccountModel, user: SessionUser): Html =>
+/** A stored notice key (plus any data it carries) turned into this language's copy. */
+const noticeText = (msgs: AccountMessages, notice: AccountNotice): string =>
+    typeof notice === "string" ? msgs.notices[notice] : msgs.signedOutSessions(notice.revoked);
+
+export const accountView = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: AccountMessages,
+    language: Language,
+    model: AccountModel,
+    user: SessionUser
+): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center p-8 pt-24")],
         [
-            appBackLink(h, "/towers/@me", "← Back to My Towers"),
+            appBackLink(h, "/towers/@me", msgs.backToTowers),
             h.div(
                 [h.Class("flex w-full max-w-2xl flex-col gap-6")],
                 [
-                    h.h1([h.Class("font-pixel text-dark-blue text-lg")], [`${user.displayName}'s account`]),
+                    h.h1([h.Class("font-pixel text-dark-blue text-lg")], [msgs.heading(user.displayName)]),
                     ...Option.match(model.notice, {
-                        onSome: (text) => [banner(h, "notice", text)],
+                        onSome: (notice) => [banner(h, "notice", noticeText(msgs, notice))],
                         onNone: () => [],
                     }),
                     ...Option.match(model.problem, {
-                        onSome: (text) => [banner(h, "problem", text)],
+                        onSome: (problem) => [banner(h, "problem", msgs.problems[problem])],
                         onNone: () => [],
                     }),
-                    sessionsSection(h, model),
-                    accountsSection(h, model),
+                    sessionsSection(h, msgs, language, model),
+                    accountsSection(h, msgs, model),
                 ]
             ),
         ]

--- a/apps/tinyburg.app/client/pages/developerApps.ts
+++ b/apps/tinyburg.app/client/pages/developerApps.ts
@@ -1,3 +1,4 @@
+import type { DeveloperAppsMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { appBackLink } from "../ui/chrome.ts";
@@ -7,29 +8,21 @@ import { appBackLink } from "../ui/chrome.ts";
  * reads clients straight from the database yet exposes no management
  * endpoints. The page says so rather than calling something that isn't there.
  */
-export const developerAppsView = <M>(h: HtmlBuilder<M>): Html =>
+export const developerAppsView = <M>(h: HtmlBuilder<M>, msgs: DeveloperAppsMessages, shared: SharedMessages): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center p-8 pt-24")],
         [
-            appBackLink(h, "/", "← Back to Home"),
+            appBackLink(h, "/", shared.backToHome),
             h.div(
                 [h.Class("bg-card-bg shadow-pixel-hover border-gold w-full max-w-2xl rounded-2xl border-3 p-8")],
                 [
-                    h.h1([h.Class("font-pixel mb-6 text-lg text-gray-800")], ["OAuth Applications"]),
+                    h.h1([h.Class("font-pixel mb-6 text-lg text-gray-800")], [msgs.heading]),
                     h.div(
                         [h.Class("rounded-lg border-2 border-dashed border-gray-300 p-8 text-center")],
                         [
                             h.div([h.Class("mb-3 text-4xl")], ["🛠️"]),
-                            h.p(
-                                [h.Class("font-mono mb-1 text-2xl text-gray-600")],
-                                ["Self-serve registration is coming"]
-                            ),
-                            h.p(
-                                [h.Class("font-mono text-lg text-gray-500")],
-                                [
-                                    "Sign in with Tinyburg already works. Ask in the Discord and we'll register your application by hand in the meantime.",
-                                ]
-                            ),
+                            h.p([h.Class("font-mono mb-1 text-2xl text-gray-600")], [msgs.comingSoon]),
+                            h.p([h.Class("font-mono text-lg text-gray-500")], [msgs.comingSoonDetail]),
                         ]
                     ),
                     h.a(
@@ -37,7 +30,7 @@ export const developerAppsView = <M>(h: HtmlBuilder<M>): Html =>
                             h.Href("/developers"),
                             h.Class("font-mono text-sky-dark mt-6 inline-block text-lg hover:underline"),
                         ],
-                        ["← Read the integration guide"]
+                        [msgs.readGuide]
                     ),
                 ]
             ),

--- a/apps/tinyburg.app/client/pages/developers.ts
+++ b/apps/tinyburg.app/client/pages/developers.ts
@@ -1,3 +1,4 @@
+import type { DevelopersMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { articleBackLink, articleHeading } from "../ui/chrome.ts";
@@ -6,37 +7,13 @@ import { articleBackLink, articleHeading } from "../ui/chrome.ts";
 // server-rendered page which built them from the configured site origin.
 const site = "https://tinyburg.app";
 
-const endpoints = [
-    { name: "JWKS", url: `${site}/.well-known/jwks.json` },
-    { name: "Discovery", url: `${site}/.well-known/openid-configuration` },
-    { name: "Authorization", url: `${site}/oauth/authorize` },
-    { name: "Token", url: `${site}/oauth/token` },
-    { name: "Userinfo", url: `${site}/oauth/userinfo` },
-];
-
-const scopes = [
-    { name: "openid", description: "Confirm your Tinyburg identity" },
-    { name: "profile", description: "See your display name and avatar" },
-];
-
-const steps = [
-    {
-        title: "Log In to Tinyburg",
-        description: "You need a Tinyburg account to register applications",
-    },
-    {
-        title: "Register Your Application",
-        description: "Give it a name and your redirect uris, then grab your client id and secret",
-    },
-    {
-        title: "Point Your OIDC Library at Us",
-        description: "Most libraries only need the discovery url below to configure themselves",
-    },
-    {
-        title: "Players Sign In",
-        description: "They approve your app once and arrive back at your redirect uri",
-    },
-];
+const endpointUrls = {
+    jwks: `${site}/.well-known/jwks.json`,
+    discovery: `${site}/.well-known/openid-configuration`,
+    authorization: `${site}/oauth/authorize`,
+    token: `${site}/oauth/token`,
+    userinfo: `${site}/oauth/userinfo`,
+};
 
 const featureCard = <M>(h: HtmlBuilder<M>, icon: string, title: string, description: string): Html =>
     h.div(
@@ -48,11 +25,26 @@ const featureCard = <M>(h: HtmlBuilder<M>, icon: string, title: string, descript
         ]
     );
 
-export const developersView = <M>(h: HtmlBuilder<M>): Html =>
-    h.div(
+export const developersView = <M>(h: HtmlBuilder<M>, msgs: DevelopersMessages, shared: SharedMessages): Html => {
+    const endpoints = [
+        { name: msgs.endpointNames.jwks, url: endpointUrls.jwks },
+        { name: msgs.endpointNames.discovery, url: endpointUrls.discovery },
+        { name: msgs.endpointNames.authorization, url: endpointUrls.authorization },
+        { name: msgs.endpointNames.token, url: endpointUrls.token },
+        { name: msgs.endpointNames.userinfo, url: endpointUrls.userinfo },
+    ];
+
+    const scopes = [
+        { name: "openid", description: msgs.scopeDescriptions.openid },
+        { name: "profile", description: msgs.scopeDescriptions.profile },
+    ];
+
+    const steps = [msgs.steps.logIn, msgs.steps.register, msgs.steps.point, msgs.steps.signIn];
+
+    return h.div(
         [h.Class("relative min-h-screen px-4 py-16 sm:px-8 sm:py-20")],
         [
-            articleBackLink(h, "/", "Back"),
+            articleBackLink(h, "/", shared.back),
             h.article(
                 [h.Class("mx-auto max-w-3xl")],
                 [
@@ -70,12 +62,9 @@ export const developersView = <M>(h: HtmlBuilder<M>): Html =>
                                         "font-pixel text-dark-blue mb-2 text-base leading-relaxed sm:text-lg md:text-xl"
                                     ),
                                 ],
-                                ["Tinyburg for Developers"]
+                                [msgs.title]
                             ),
-                            h.p(
-                                [h.Class("text-text-dark/80 text-xl")],
-                                ["Let players bring their Tinyburg account to your app"]
-                            ),
+                            h.p([h.Class("text-text-dark/80 text-xl")], [msgs.tagline]),
                         ]
                     ),
                     h.div(
@@ -88,33 +77,28 @@ export const developersView = <M>(h: HtmlBuilder<M>): Html =>
                             h.section(
                                 [h.Class("pb-8")],
                                 [
-                                    articleHeading(h, "Sign in with Tinyburg"),
-                                    h.p(
-                                        [h.Class("mb-4 text-xl leading-relaxed sm:text-xl")],
-                                        [
-                                            "Tinyburg is an OpenID Connect provider. Building a companion tool, a Discord bot dashboard, or anything else for the TinyTower community? Register an OAuth application and players can sign in to it with the same account they use to trade, no new passwords required.",
-                                        ]
-                                    ),
+                                    articleHeading(h, msgs.signInHeading),
+                                    h.p([h.Class("mb-4 text-xl leading-relaxed sm:text-xl")], [msgs.signInBody]),
                                     h.div(
                                         [h.Class("mt-6 grid grid-cols-1 gap-6 md:grid-cols-3")],
                                         [
                                             featureCard(
                                                 h,
                                                 "🔐",
-                                                "Standard OIDC",
-                                                "Authorization code flow with PKCE and ES256-signed id tokens. Any OpenID Connect client library works out of the box."
+                                                msgs.features.standardOidc.title,
+                                                msgs.features.standardOidc.description
                                             ),
                                             featureCard(
                                                 h,
                                                 "🪶",
-                                                "Minimal Scopes",
-                                                "Apps only see a player's identity, display name, and avatar. Nothing else leaves Tinyburg."
+                                                msgs.features.minimalScopes.title,
+                                                msgs.features.minimalScopes.description
                                             ),
                                             featureCard(
                                                 h,
                                                 "🤝",
-                                                "Player Consent",
-                                                "Players approve exactly what your app can see on a consent screen before any tokens are issued."
+                                                msgs.features.playerConsent.title,
+                                                msgs.features.playerConsent.description
                                             ),
                                         ]
                                     ),
@@ -123,7 +107,7 @@ export const developersView = <M>(h: HtmlBuilder<M>): Html =>
                             h.section(
                                 [h.Class("py-8")],
                                 [
-                                    articleHeading(h, "Getting Started"),
+                                    articleHeading(h, msgs.gettingStartedHeading),
                                     h.div(
                                         [h.Class("mt-4 flex flex-col gap-4")],
                                         steps.map((step, index) =>
@@ -163,24 +147,14 @@ export const developersView = <M>(h: HtmlBuilder<M>): Html =>
                                             )
                                         )
                                     ),
-                                    h.p(
-                                        [h.Class("mt-6 text-xl leading-relaxed sm:text-xl")],
-                                        [
-                                            "Redirect uris must use https, except for localhost while you develop. Client secrets are shown once at registration and stored hashed, so keep yours somewhere safe.",
-                                        ]
-                                    ),
+                                    h.p([h.Class("mt-6 text-xl leading-relaxed sm:text-xl")], [msgs.redirectNote]),
                                 ]
                             ),
                             h.section(
                                 [h.Class("py-8")],
                                 [
-                                    articleHeading(h, "Endpoints"),
-                                    h.p(
-                                        [h.Class("mb-4 text-xl leading-relaxed sm:text-xl")],
-                                        [
-                                            "Everything below is also published in the discovery document, so most setups only ever need the first url.",
-                                        ]
-                                    ),
+                                    articleHeading(h, msgs.endpointsHeading),
+                                    h.p([h.Class("mb-4 text-xl leading-relaxed sm:text-xl")], [msgs.endpointsBody]),
                                     h.div(
                                         [h.Class("flex flex-col gap-3")],
                                         endpoints.map((endpoint) =>
@@ -208,7 +182,7 @@ export const developersView = <M>(h: HtmlBuilder<M>): Html =>
                             h.section(
                                 [h.Class("py-8")],
                                 [
-                                    articleHeading(h, "Scopes"),
+                                    articleHeading(h, msgs.scopesHeading),
                                     h.div(
                                         [h.Class("flex flex-col gap-3")],
                                         scopes.map((scope) =>
@@ -236,11 +210,11 @@ export const developersView = <M>(h: HtmlBuilder<M>): Html =>
                             h.section(
                                 [h.Class("pt-8")],
                                 [
-                                    articleHeading(h, "Ready to Build?"),
+                                    articleHeading(h, msgs.readyHeading),
                                     h.p(
                                         [h.Class("mb-4 text-xl leading-relaxed sm:text-xl")],
                                         [
-                                            "Register your first application and start signing players in. Questions or stuck on something? Ask in the ",
+                                            msgs.readyBefore,
                                             h.a(
                                                 [
                                                     h.Href("https://discord.gg/tinyburg"),
@@ -248,9 +222,9 @@ export const developersView = <M>(h: HtmlBuilder<M>): Html =>
                                                         "text-sky-dark decoration-sky-dark/30 hover:decoration-sky-dark underline decoration-2 underline-offset-2 transition-colors"
                                                     ),
                                                 ],
-                                                ["Tinyburg Discord"]
+                                                [msgs.discordLinkLabel]
                                             ),
-                                            " and we'll help you out.",
+                                            msgs.readyAfter,
                                         ]
                                     ),
                                     h.div(
@@ -263,16 +237,17 @@ export const developersView = <M>(h: HtmlBuilder<M>): Html =>
                                                         "font-pixel bg-gold shadow-pixel hover:shadow-pixel-hover flex items-center justify-center gap-2 rounded-lg px-5 py-4 text-[0.7rem] text-gray-800 transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                                     ),
                                                 ],
-                                                ["Your Applications"]
+                                                [msgs.yourApplications]
                                             ),
                                             h.a(
                                                 [
-                                                    h.Href(endpoints[0]?.url ?? site),
+                                                    // Kept pointing at the first listed endpoint, as before.
+                                                    h.Href(endpointUrls.jwks),
                                                     h.Class(
                                                         "font-pixel bg-dark-blue/95 shadow-pixel hover:shadow-pixel-hover flex items-center justify-center gap-2 rounded-lg px-5 py-4 text-[0.7rem] text-white transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                                     ),
                                                 ],
-                                                ["Discovery Document"]
+                                                [msgs.discoveryDocument]
                                             ),
                                         ]
                                     ),
@@ -284,3 +259,4 @@ export const developersView = <M>(h: HtmlBuilder<M>): Html =>
             ),
         ]
     );
+};

--- a/apps/tinyburg.app/client/pages/home.ts
+++ b/apps/tinyburg.app/client/pages/home.ts
@@ -1,27 +1,5 @@
+import type { HomeMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
-
-const features = [
-    {
-        icon: "🏢",
-        title: "Trade Bitizens",
-        description: "Find dream jobbers for your tower or trade away duplicates",
-    },
-    {
-        icon: "🎨",
-        title: "Costumes & Pets",
-        description: "Collect rare costumes and adorable pets for your bitizens",
-    },
-    {
-        icon: "🏆",
-        title: "Golden Tickets",
-        description: "Exchange resources and help fellow tower builders",
-    },
-    {
-        icon: "🤝",
-        title: "Community",
-        description: "Connect with thousands of active TinyTower players",
-    },
-];
 
 const navLink = <M>(h: HtmlBuilder<M>, href: string, label: string): Html =>
     h.a([h.Href(href), h.Class("hover:text-gold text-xl text-white no-underline transition-colors")], [label]);
@@ -32,23 +10,30 @@ const footerLink = <M>(h: HtmlBuilder<M>, href: string, label: string): Html =>
         [label]
     );
 
-const heroTower = <M>(h: HtmlBuilder<M>): Html =>
+const heroTower = <M>(h: HtmlBuilder<M>, floors: SharedMessages["floors"]): Html =>
     h.div(
         [h.Class("tower tower--hero")],
         [
             h.div([h.Class("floor roof")], ["🏗️"]),
-            h.div([h.Class("floor food")], ["🍕 Food"]),
-            h.div([h.Class("floor retail")], ["🛍️ Retail"]),
-            h.div([h.Class("floor service")], ["✂️ Service"]),
-            h.div([h.Class("floor creative")], ["🎨 Creative"]),
-            h.div([h.Class("floor recreation")], ["🎮 Recreation"]),
-            h.div([h.Class("floor residential")], ["🛏️ Residential"]),
-            h.div([h.Class("floor lobby")], ["🚪 Lobby"]),
+            h.div([h.Class("floor food")], [floors.food]),
+            h.div([h.Class("floor retail")], [floors.retail]),
+            h.div([h.Class("floor service")], [floors.service]),
+            h.div([h.Class("floor creative")], [floors.creative]),
+            h.div([h.Class("floor recreation")], [floors.recreation]),
+            h.div([h.Class("floor residential")], [floors.residential]),
+            h.div([h.Class("floor lobby")], [floors.lobby]),
         ]
     );
 
-export const homeView = <M>(h: HtmlBuilder<M>): Html =>
-    h.div(
+export const homeView = <M>(h: HtmlBuilder<M>, msgs: HomeMessages, shared: SharedMessages): Html => {
+    const features = [
+        { icon: "🏢", ...msgs.features.tradeBitizens },
+        { icon: "🎨", ...msgs.features.costumesPets },
+        { icon: "🏆", ...msgs.features.goldenTickets },
+        { icon: "🤝", ...msgs.features.community },
+    ];
+
+    return h.div(
         [],
         [
             h.header(
@@ -67,10 +52,10 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                             h.div(
                                 [h.Class("hidden gap-8 md:flex")],
                                 [
-                                    navLink(h, "/trades", "Browse Trades"),
-                                    navLink(h, "/bitizens", "Bitizens"),
-                                    navLink(h, "/costumes", "Costumes"),
-                                    navLink(h, "/about", "About"),
+                                    navLink(h, "/trades", msgs.nav.browseTrades),
+                                    navLink(h, "/bitizens", msgs.nav.bitizens),
+                                    navLink(h, "/costumes", msgs.nav.costumes),
+                                    navLink(h, "/about", msgs.nav.about),
                                 ]
                             ),
                             h.a(
@@ -80,7 +65,7 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                                         "font-pixel bg-gold text-dark-blue shadow-pixel hover:shadow-pixel-hover px-6 py-3 text-[0.7rem] transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                     ),
                                 ],
-                                ["Log In"]
+                                [msgs.logIn]
                             ),
                         ]
                     ),
@@ -106,7 +91,7 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                                                 "font-pixel mb-6 text-2xl leading-relaxed text-white drop-shadow-[4px_4px_0_var(--color-dark-blue)] md:text-4xl"
                                             ),
                                         ],
-                                        ["TinyTower Trading"]
+                                        [msgs.heroTitle]
                                     ),
                                     h.p(
                                         [
@@ -114,9 +99,7 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                                                 "mb-8 text-2xl leading-relaxed text-white drop-shadow-[2px_2px_0_rgba(0,0,0,0.3)]"
                                             ),
                                         ],
-                                        [
-                                            "The community marketplace for trading bitizens, costumes, pets, and more with TinyTower players worldwide",
-                                        ]
+                                        [msgs.heroTagline]
                                     ),
                                     h.div(
                                         [h.Class("flex flex-wrap justify-center gap-4 lg:justify-start")],
@@ -128,7 +111,7 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                                                         "font-pixel bg-gold text-dark-blue shadow-pixel hover:shadow-pixel-hover px-8 py-4 text-sm transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-[#ffe44d]"
                                                     ),
                                                 ],
-                                                ["Start Trading"]
+                                                [msgs.startTrading]
                                             ),
                                             h.a(
                                                 [
@@ -137,13 +120,13 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                                                         "font-pixel shadow-pixel hover:shadow-pixel-hover border-3 border-white bg-transparent px-8 py-4 text-sm text-white transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-white/10"
                                                     ),
                                                 ],
-                                                ["Learn More"]
+                                                [msgs.learnMore]
                                             ),
                                         ]
                                     ),
                                 ]
                             ),
-                            h.div([h.Class("flex justify-center")], [heroTower(h)]),
+                            h.div([h.Class("flex justify-center")], [heroTower(h, shared.floors)]),
                         ]
                     ),
                     h.section(
@@ -155,7 +138,7 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                                         "font-pixel mb-12 text-2xl text-white drop-shadow-[3px_3px_0_var(--color-dark-blue)]"
                                     ),
                                 ],
-                                ["What Can You Trade?"]
+                                [msgs.featuresHeading]
                             ),
                             h.div(
                                 [h.Class("grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4")],
@@ -182,9 +165,9 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                     h.section(
                         [h.Class("relative z-10 mx-auto flex max-w-6xl flex-wrap justify-center gap-16 px-8 py-16")],
                         [
-                            ["10K+", "Active Traders"],
-                            ["50K+", "Trades Completed"],
-                            ["1M+", "Bitizens Traded"],
+                            ["10K+", msgs.stats.activeTraders],
+                            ["50K+", msgs.stats.tradesCompleted],
+                            ["1M+", msgs.stats.bitizensTraded],
                         ].map(([stat, label]) =>
                             h.div(
                                 [
@@ -206,14 +189,8 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                             ),
                         ],
                         [
-                            h.h2(
-                                [h.Class("font-pixel text-gold mb-4 text-xl leading-relaxed")],
-                                ["Ready to Build Your Dream Tower?"]
-                            ),
-                            h.p(
-                                [h.Class("mb-8 text-2xl text-white")],
-                                ["Join thousands of players trading bitizens and items every day"]
-                            ),
+                            h.h2([h.Class("font-pixel text-gold mb-4 text-xl leading-relaxed")], [msgs.ctaHeading]),
+                            h.p([h.Class("mb-8 text-2xl text-white")], [msgs.ctaBody]),
                             h.a(
                                 [
                                     h.Href("/login"),
@@ -221,7 +198,7 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                                         "font-pixel bg-gold text-dark-blue shadow-pixel hover:shadow-pixel-hover inline-block px-10 py-5 text-base transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-[#ffe44d]"
                                     ),
                                 ],
-                                ["Get Started Free"]
+                                [msgs.ctaButton]
                             ),
                         ]
                     ),
@@ -240,7 +217,7 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                                     h.p(
                                         [h.Class("text-lg leading-relaxed text-white/90")],
                                         [
-                                            "A community-driven trading platform for TinyTower enthusiasts. Not affiliated with NimbleBit. Source code is available on ",
+                                            msgs.footerAbout.before,
                                             h.a(
                                                 [
                                                     h.Href("https://github.com/leonitousconforti/tinyburg"),
@@ -248,8 +225,9 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                                                     h.Rel("noopener"),
                                                     h.Class("text-gold hover:underline"),
                                                 ],
-                                                ["GitHub"]
+                                                [msgs.footerAbout.linkLabel]
                                             ),
+                                            msgs.footerAbout.after,
                                         ]
                                     ),
                                 ]
@@ -257,41 +235,37 @@ export const homeView = <M>(h: HtmlBuilder<M>): Html =>
                             h.div(
                                 [],
                                 [
-                                    h.h4([h.Class("font-pixel text-gold mb-4 text-sm")], ["Quick Links"]),
-                                    footerLink(h, "/trades", "Browse Trades"),
-                                    footerLink(h, "/bitizens", "Bitizens"),
-                                    footerLink(h, "/costumes", "Costumes"),
+                                    h.h4([h.Class("font-pixel text-gold mb-4 text-sm")], [msgs.quickLinks]),
+                                    footerLink(h, "/trades", msgs.nav.browseTrades),
+                                    footerLink(h, "/bitizens", msgs.nav.bitizens),
+                                    footerLink(h, "/costumes", msgs.nav.costumes),
                                 ]
                             ),
                             h.div(
                                 [],
                                 [
-                                    h.h4([h.Class("font-pixel text-gold mb-4 text-sm")], ["Community"]),
+                                    h.h4([h.Class("font-pixel text-gold mb-4 text-sm")], [msgs.community]),
                                     footerLink(h, "/discord", "Discord"),
                                     footerLink(h, "/reddit", "Reddit"),
-                                    footerLink(h, "/sponsors", "Sponsors"),
+                                    footerLink(h, "/sponsors", msgs.sponsors),
                                 ]
                             ),
                             h.div(
                                 [],
                                 [
-                                    h.h4([h.Class("font-pixel text-gold mb-4 text-sm")], ["Legal"]),
-                                    footerLink(h, "/privacy", "Privacy Policy"),
-                                    footerLink(h, "/terms", "Terms of Service"),
+                                    h.h4([h.Class("font-pixel text-gold mb-4 text-sm")], [msgs.legal]),
+                                    footerLink(h, "/privacy", msgs.privacyPolicy),
+                                    footerLink(h, "/terms", msgs.termsOfService),
                                 ]
                             ),
                         ]
                     ),
                     h.div(
                         [h.Class("mx-auto max-w-6xl border-t border-white/10 px-8 py-6 text-center")],
-                        [
-                            h.p(
-                                [h.Class("text-base text-white/70")],
-                                ["© 2026 Tinyburg. TinyTower is a trademark of NimbleBit LLC."]
-                            ),
-                        ]
+                        [h.p([h.Class("text-base text-white/70")], [msgs.copyright])]
                     ),
                 ]
             ),
         ]
     );
+};

--- a/apps/tinyburg.app/client/pages/login.ts
+++ b/apps/tinyburg.app/client/pages/login.ts
@@ -1,5 +1,6 @@
 import { Match, Option } from "effect";
 
+import type { LoginMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { classifyOAuthError } from "../oauthErrors.ts";
@@ -17,21 +18,12 @@ const loginHrefFor = (provider: "google" | "discord", returnTo: Option.Option<st
  * could not be completed. Cancelling is not a failure and does not read like
  * one; the rest differ only in what the visitor should try next.
  */
-const problemFor = (error: string): { readonly denied: boolean; readonly text: string } =>
+const problemFor = (msgs: LoginMessages, error: string): { readonly denied: boolean; readonly text: string } =>
     Match.value(classifyOAuthError(error)).pipe(
         Match.withReturnType<{ readonly denied: boolean; readonly text: string }>(),
-        Match.when("denied", () => ({
-            denied: true,
-            text: "Sign in was cancelled. You can pick up where you left off whenever you like.",
-        })),
-        Match.when("expired", () => ({
-            denied: false,
-            text: "That sign in attempt expired or was interrupted. Please start again, and check that your browser allows cookies for this site.",
-        })),
-        Match.when("failed", () => ({
-            denied: false,
-            text: "We couldn't finish signing you in. Please try again.",
-        })),
+        Match.when("denied", () => ({ denied: true, text: msgs.problems.denied })),
+        Match.when("expired", () => ({ denied: false, text: msgs.problems.expired })),
+        Match.when("failed", () => ({ denied: false, text: msgs.problems.failed })),
         Match.exhaustive
     );
 
@@ -54,27 +46,30 @@ const perk = <M>(h: HtmlBuilder<M>, icon: string, text: string): Html =>
         [h.span([h.Class("text-xl")], [icon]), h.span([], [text])]
     );
 
-export const loginView = <M>(h: HtmlBuilder<M>, returnTo: Option.Option<string>, error: Option.Option<string>): Html =>
+export const loginView = <M>(
+    h: HtmlBuilder<M>,
+    msgs: LoginMessages,
+    shared: SharedMessages,
+    returnTo: Option.Option<string>,
+    error: Option.Option<string>
+): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center justify-center p-8")],
         [
-            appBackLink(h, "/", "← Back to Home"),
+            appBackLink(h, "/", shared.backToHome),
             h.div(
                 [h.Class("bg-card-bg shadow-pixel-hover border-gold w-full max-w-md rounded-2xl border-3 p-8")],
                 [
                     h.div(
                         [h.Class("mb-8 text-center")],
                         [
-                            h.h1([h.Class("font-pixel mb-2 text-lg text-gray-800")], ["Welcome to Tinyburg"]),
-                            h.p(
-                                [h.Class("font-mono text-xl text-gray-600")],
-                                ["Sign in or create an account to get started"]
-                            ),
+                            h.h1([h.Class("font-pixel mb-2 text-lg text-gray-800")], [msgs.heading]),
+                            h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.subheading]),
                         ]
                     ),
                     ...Option.match(error, {
                         onSome: (code) => {
-                            const { denied, text } = problemFor(code);
+                            const { denied, text } = problemFor(msgs, code);
                             return [problemBanner(h, denied, text)];
                         },
                         onNone: () => [],
@@ -89,7 +84,7 @@ export const loginView = <M>(h: HtmlBuilder<M>, returnTo: Option.Option<string>,
                                         "shadow-pixel hover:shadow-pixel-hover hover:border-sky-blue flex w-full items-center justify-center gap-3 rounded-lg border-2 border-gray-300 bg-white px-6 py-4 font-mono text-xl text-gray-800 no-underline transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                     ),
                                 ],
-                                [googleIcon(h, "h-6 w-6 shrink-0"), h.span([], ["Continue with Google"])]
+                                [googleIcon(h, "h-6 w-6 shrink-0"), h.span([], [msgs.continueWithGoogle])]
                             ),
                             h.a(
                                 [
@@ -98,16 +93,16 @@ export const loginView = <M>(h: HtmlBuilder<M>, returnTo: Option.Option<string>,
                                         "bg-discord shadow-pixel hover:shadow-pixel-hover flex w-full items-center justify-center gap-3 rounded-lg px-6 py-4 font-mono text-xl text-white no-underline transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-[#4752c4]"
                                     ),
                                 ],
-                                [discordIcon(h, "h-6 w-6 shrink-0"), h.span([], ["Continue with Discord"])]
+                                [discordIcon(h, "h-6 w-6 shrink-0"), h.span([], [msgs.continueWithDiscord])]
                             ),
                         ]
                     ),
                     h.div(
                         [h.Class("bg-sky-blue/10 border-sky-blue/20 mt-8 flex flex-col gap-2 rounded-lg border-2 p-4")],
                         [
-                            perk(h, "🎯", "Find dream job bitizens"),
-                            perk(h, "🤝", "Trade with thousands of players"),
-                            perk(h, "🎨", "Collect rare costumes & pets"),
+                            perk(h, "🎯", msgs.perks.dreamJobs),
+                            perk(h, "🤝", msgs.perks.trade),
+                            perk(h, "🎨", msgs.perks.collect),
                         ]
                     ),
                     h.div(
@@ -116,15 +111,15 @@ export const loginView = <M>(h: HtmlBuilder<M>, returnTo: Option.Option<string>,
                             h.p(
                                 [h.Class("text-text-dark/70 text-base")],
                                 [
-                                    "By continuing, you agree to our ",
+                                    msgs.agreeBefore,
                                     h.a(
                                         [h.Href("/terms"), h.Class("text-sky-dark no-underline hover:underline")],
-                                        ["Terms of Service"]
+                                        [msgs.termsOfService]
                                     ),
-                                    " and ",
+                                    msgs.agreeAnd,
                                     h.a(
                                         [h.Href("/privacy"), h.Class("text-sky-dark no-underline hover:underline")],
-                                        ["Privacy Policy"]
+                                        [msgs.privacyPolicy]
                                     ),
                                 ]
                             ),

--- a/apps/tinyburg.app/client/pages/notFound.ts
+++ b/apps/tinyburg.app/client/pages/notFound.ts
@@ -1,6 +1,7 @@
+import type { NotFoundMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
-export const notFoundView = <M>(h: HtmlBuilder<M>): Html =>
+export const notFoundView = <M>(h: HtmlBuilder<M>, msgs: NotFoundMessages, shared: SharedMessages): Html =>
     h.main(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center justify-center px-6 py-16 text-center")],
         [
@@ -8,10 +9,10 @@ export const notFoundView = <M>(h: HtmlBuilder<M>): Html =>
                 [h.Class("tower tower--404 mb-10"), h.AriaHidden(true)],
                 [
                     h.div([h.Class("floor roof")], ["🏗️"]),
-                    h.div([h.Class("floor food")], ["🍕 Food"]),
+                    h.div([h.Class("floor food")], [shared.floors.food]),
                     h.div([h.Class("floor missing")], ["404"]),
-                    h.div([h.Class("floor recreation")], ["🎮 Recreation"]),
-                    h.div([h.Class("floor lobby")], ["🚪 Lobby"]),
+                    h.div([h.Class("floor recreation")], [shared.floors.recreation]),
+                    h.div([h.Class("floor lobby")], [shared.floors.lobby]),
                 ]
             ),
             h.h1(
@@ -20,11 +21,11 @@ export const notFoundView = <M>(h: HtmlBuilder<M>): Html =>
                         "font-pixel text-xl leading-relaxed text-white drop-shadow-[3px_3px_0_var(--color-dark-blue)] sm:text-3xl"
                     ),
                 ],
-                ["Floor Not Found"]
+                [msgs.heading]
             ),
             h.p(
                 [h.Class("mt-4 max-w-md text-xl text-white drop-shadow-[2px_2px_0_rgba(0,0,0,0.3)] sm:text-2xl")],
-                ["Maybe the bitizens moved this floor? Try the lobby instead!"]
+                [msgs.body]
             ),
             h.div(
                 [h.Class("mt-10 flex flex-wrap justify-center gap-4")],
@@ -36,7 +37,7 @@ export const notFoundView = <M>(h: HtmlBuilder<M>): Html =>
                                 "font-pixel bg-gold text-dark-blue shadow-pixel hover:shadow-pixel-hover px-8 py-4 text-sm transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-[#ffe44d]"
                             ),
                         ],
-                        ["Go Home"]
+                        [msgs.goHome]
                     ),
                     h.button(
                         [
@@ -45,7 +46,7 @@ export const notFoundView = <M>(h: HtmlBuilder<M>): Html =>
                                 "font-pixel shadow-pixel hover:shadow-pixel-hover border-3 cursor-pointer border-white bg-transparent px-8 py-4 text-sm text-white transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-white/10"
                             ),
                         ],
-                        ["Go Back"]
+                        [msgs.goBack]
                     ),
                 ]
             ),

--- a/apps/tinyburg.app/client/pages/sponsors.ts
+++ b/apps/tinyburg.app/client/pages/sponsors.ts
@@ -1,3 +1,4 @@
+import type { SharedMessages, SponsorsMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { articleBackLink, articleHeading } from "../ui/chrome.ts";
@@ -62,11 +63,11 @@ const pastSponsorChip = <M>(h: HtmlBuilder<M>, sponsor: Sponsor): Html =>
         ]
     );
 
-export const sponsorsView = <M>(h: HtmlBuilder<M>): Html =>
+export const sponsorsView = <M>(h: HtmlBuilder<M>, msgs: SponsorsMessages, shared: SharedMessages): Html =>
     h.div(
         [h.Class("relative min-h-screen px-4 py-16 sm:px-8 sm:py-20")],
         [
-            articleBackLink(h, "/", "Back"),
+            articleBackLink(h, "/", shared.back),
             h.article(
                 [h.Class("mx-auto max-w-3xl")],
                 [
@@ -84,12 +85,9 @@ export const sponsorsView = <M>(h: HtmlBuilder<M>): Html =>
                                         "font-pixel text-dark-blue mb-2 text-base leading-relaxed sm:text-lg md:text-xl"
                                     ),
                                 ],
-                                ["Thank You, Sponsors!"]
+                                [msgs.title]
                             ),
-                            h.p(
-                                [h.Class("text-text-dark/80 text-xl")],
-                                ["The people keeping the lights on in every floor"]
-                            ),
+                            h.p([h.Class("text-text-dark/80 text-xl")], [msgs.tagline]),
                         ]
                     ),
                     h.div(
@@ -102,12 +100,7 @@ export const sponsorsView = <M>(h: HtmlBuilder<M>): Html =>
                             h.section(
                                 [h.Class("pb-8")],
                                 [
-                                    h.p(
-                                        [h.Class("mb-6 text-xl leading-relaxed sm:text-xl")],
-                                        [
-                                            "Tinyburg is free, open source, and run by volunteers. The servers, the database, and the treasury that escrows every trade are all paid for by the generous people on this page who sponsor the project on GitHub. Every single one of them makes the tower a little taller.",
-                                        ]
-                                    ),
+                                    h.p([h.Class("mb-6 text-xl leading-relaxed sm:text-xl")], [msgs.intro]),
                                     h.a(
                                         [
                                             h.Href(sponsorsUrl),
@@ -117,14 +110,14 @@ export const sponsorsView = <M>(h: HtmlBuilder<M>): Html =>
                                                 "font-pixel shadow-pixel hover:shadow-pixel-hover inline-flex items-center gap-2 rounded-lg bg-[#ea4aaa] px-5 py-4 text-[0.65rem] text-white transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-[#d43a99]"
                                             ),
                                         ],
-                                        [h.span([], ["💖"]), " Become a Sponsor"]
+                                        [h.span([], ["💖"]), ` ${msgs.becomeSponsor}`]
                                     ),
                                 ]
                             ),
                             h.section(
                                 [h.Class("py-8")],
                                 [
-                                    articleHeading(h, "Current Sponsors"),
+                                    articleHeading(h, msgs.currentHeading),
                                     currentSponsors.length === 0
                                         ? h.div(
                                               [
@@ -134,10 +127,7 @@ export const sponsorsView = <M>(h: HtmlBuilder<M>): Html =>
                                               ],
                                               [
                                                   h.span([h.Class("mb-3 block text-4xl")], ["🌱"]),
-                                                  h.p(
-                                                      [h.Class("text-xl leading-relaxed")],
-                                                      ["No sponsors yet. Be the first bitizen on this floor!"]
-                                                  ),
+                                                  h.p([h.Class("text-xl leading-relaxed")], [msgs.noSponsors]),
                                               ]
                                           )
                                         : h.div(
@@ -150,13 +140,8 @@ export const sponsorsView = <M>(h: HtmlBuilder<M>): Html =>
                                 ? h.section(
                                       [h.Class("py-8")],
                                       [
-                                          articleHeading(h, "Past Sponsors"),
-                                          h.p(
-                                              [h.Class("mb-4 text-xl leading-relaxed")],
-                                              [
-                                                  "Once a sponsor, always appreciated. Thank you for helping along the way!",
-                                              ]
-                                          ),
+                                          articleHeading(h, msgs.pastHeading),
+                                          h.p([h.Class("mb-4 text-xl leading-relaxed")], [msgs.pastBody]),
                                           h.div(
                                               [h.Class("flex flex-wrap gap-3")],
                                               pastSponsors.map((sponsor) => pastSponsorChip(h, sponsor))
@@ -167,13 +152,8 @@ export const sponsorsView = <M>(h: HtmlBuilder<M>): Html =>
                             h.section(
                                 [h.Class("pt-8")],
                                 [
-                                    articleHeading(h, "Other Ways to Help"),
-                                    h.p(
-                                        [h.Class("mb-6 text-xl leading-relaxed")],
-                                        [
-                                            "Sponsoring is not the only way to support Tinyburg. Report bugs, contribute a feature, or just hang out and help other tower builders in the community.",
-                                        ]
-                                    ),
+                                    articleHeading(h, msgs.otherWaysHeading),
+                                    h.p([h.Class("mb-6 text-xl leading-relaxed")], [msgs.otherWaysBody]),
                                     h.div(
                                         [h.Class("flex flex-col gap-4 md:flex-row")],
                                         [
@@ -186,7 +166,7 @@ export const sponsorsView = <M>(h: HtmlBuilder<M>): Html =>
                                                         "shadow-pixel hover:shadow-pixel-hover flex items-center justify-center gap-2 rounded-lg bg-[#24292e] px-5 py-3 text-lg text-white transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-[#1a1e22]"
                                                     ),
                                                 ],
-                                                [h.span([], ["⭐"]), " Star on GitHub"]
+                                                [h.span([], ["⭐"]), ` ${msgs.starOnGithub}`]
                                             ),
                                             h.a(
                                                 [
@@ -195,7 +175,7 @@ export const sponsorsView = <M>(h: HtmlBuilder<M>): Html =>
                                                         "bg-discord shadow-pixel hover:shadow-pixel-hover flex items-center justify-center gap-2 rounded-lg px-5 py-3 text-lg text-white transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                                     ),
                                                 ],
-                                                [h.span([], ["💬"]), " Join our Discord"]
+                                                [h.span([], ["💬"]), ` ${msgs.joinDiscord}`]
                                             ),
                                         ]
                                     ),

--- a/apps/tinyburg.app/client/pages/towerLink.ts
+++ b/apps/tinyburg.app/client/pages/towerLink.ts
@@ -1,6 +1,7 @@
 import { Effect, Match, Option, Schema as S } from "effect";
 
 import type { Message as AppMessage } from "../main.ts";
+import type { TowerLinkMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { PlayerEmailSchema, PlayerIdSchema } from "@tinyburg/nimblebit-sdk/NimblebitConfig";
@@ -25,8 +26,10 @@ export const WizardModel = S.Struct({
     pendingEmail: S.String,
     submitting: S.Boolean,
     verified: S.Boolean,
-    linkError: S.Option(S.String),
-    verifyError: S.Option(S.String),
+    // Errors are stored as keys and turned into copy by the view, which is
+    // the only place that knows the language.
+    linkError: S.Option(S.Literals(["requestFailed"])),
+    verifyError: S.Option(S.Literals(["verifyFailed", "resendFailed"])),
     resend: S.Literals(["idle", "sending", "sent", "cooldown"]),
 });
 export type WizardModel = typeof WizardModel.Type;
@@ -190,10 +193,7 @@ export const updateWizard = (wizard: WizardModel, message: WizardMessage): Wizar
             FailedRequestCode: () => [
                 evo(wizard, {
                     submitting: () => false,
-                    linkError: () =>
-                        Option.some(
-                            "We couldn't reach your tower. Please double-check your friend code and try again."
-                        ),
+                    linkError: () => Option.some("requestFailed" as const),
                 }),
                 [],
             ],
@@ -210,8 +210,7 @@ export const updateWizard = (wizard: WizardModel, message: WizardMessage): Wizar
             FailedVerify: () => [
                 evo(wizard, {
                     submitting: () => false,
-                    verifyError: () =>
-                        Option.some("That code didn't work. Please check it and try again, or resend the email."),
+                    verifyError: () => Option.some("verifyFailed" as const),
                 }),
                 [],
             ],
@@ -227,7 +226,7 @@ export const updateWizard = (wizard: WizardModel, message: WizardMessage): Wizar
             FailedResend: () => [
                 evo(wizard, {
                     resend: () => "cooldown" as const,
-                    verifyError: () => Option.some("We couldn't resend the email. Please try again in a moment."),
+                    verifyError: () => Option.some("resendFailed" as const),
                 }),
                 [ResendCooldown()],
             ],
@@ -260,7 +259,7 @@ const fieldHint = <M>(h: HtmlBuilder<M>, text: string): Html =>
 const stepClass = (wizard: WizardModel): string =>
     wizard.entered === "forward" ? "step-enter-forward" : wizard.entered === "backward" ? "step-enter-backward" : "";
 
-const linkStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
+const linkStep = (wizard: WizardModel, msgs: TowerLinkMessages, h: HtmlBuilder<AppMessage>): Html =>
     h.keyed("section")(
         "link",
         [h.Class(stepClass(wizard))],
@@ -271,7 +270,7 @@ const linkStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
                     h.label(
                         [h.Class("flex flex-col gap-2")],
                         [
-                            fieldLabel(h, "Friend Code"),
+                            fieldLabel(h, msgs.friendCodeLabel),
                             h.input([
                                 h.Id("friend-code-input"),
                                 h.Type("text"),
@@ -279,7 +278,7 @@ const linkStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
                                 h.Required(true),
                                 h.Maxlength(5),
                                 h.Pattern("[0-9A-Z]{1,5}"),
-                                h.Title("Up to 5 letters or numbers"),
+                                h.Title(msgs.friendCodeTitle),
                                 h.Placeholder("ABC12"),
                                 h.Autocomplete("off"),
                                 h.Autocapitalize("characters"),
@@ -290,13 +289,13 @@ const linkStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
                                     "font-mono rounded-lg border-2 border-gray-300 bg-white p-3 text-center text-3xl tracking-[0.4em] text-gray-800 uppercase focus:border-sky-blue focus:outline-none"
                                 ),
                             ]),
-                            fieldHint(h, "You can find it on the Friends tab in TinyTower"),
+                            fieldHint(h, msgs.friendCodeHint),
                         ]
                     ),
                     h.label(
                         [h.Class("flex flex-col gap-2")],
                         [
-                            fieldLabel(h, "Cloud Sync Email"),
+                            fieldLabel(h, msgs.emailLabel),
                             h.input([
                                 h.Id("email-input"),
                                 h.Type("email"),
@@ -310,23 +309,23 @@ const linkStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
                                     "font-mono rounded-lg border-2 border-gray-300 bg-white p-3 text-xl text-gray-800 focus:border-sky-blue focus:outline-none"
                                 ),
                             ]),
-                            fieldHint(
-                                h,
-                                "The email your cloud save is registered with. Nimblebit will send a verification code to it."
-                            ),
+                            fieldHint(h, msgs.emailHint),
                         ]
                     ),
-                    errorBox(h, wizard.linkError),
+                    errorBox(
+                        h,
+                        Option.map(wizard.linkError, (key) => msgs.errors[key])
+                    ),
                     h.button(
                         [h.Type("submit"), h.Disabled(wizard.submitting), h.Class(submitButtonClass)],
-                        [wizard.submitting ? "Sending..." : "Send Verification Code"]
+                        [wizard.submitting ? msgs.sending : msgs.sendCode]
                     ),
                 ]
             ),
         ]
     );
 
-const verifyStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
+const verifyStep = (wizard: WizardModel, msgs: TowerLinkMessages, h: HtmlBuilder<AppMessage>): Html =>
     h.keyed("section")(
         "verify",
         [h.Class(stepClass(wizard))],
@@ -337,9 +336,9 @@ const verifyStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
                     h.p(
                         [h.Class("font-mono text-lg text-dark-blue")],
                         [
-                            "📬 Nimblebit sent a verification code to ",
+                            msgs.sentCodeBefore,
                             h.strong([h.Class("break-all")], [wizard.pendingEmail]),
-                            ". It can take a minute to arrive.",
+                            msgs.sentCodeAfter,
                         ]
                     ),
                 ]
@@ -350,7 +349,7 @@ const verifyStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
                     h.label(
                         [h.Class("flex flex-col gap-2")],
                         [
-                            fieldLabel(h, "Verification Code"),
+                            fieldLabel(h, msgs.codeLabel),
                             h.input([
                                 h.Id("verification-code-input"),
                                 h.Type("text"),
@@ -367,23 +366,20 @@ const verifyStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
                                     "font-mono rounded-lg border-2 border-gray-300 bg-white p-3 text-center text-3xl tracking-[0.4em] text-gray-800 focus:border-sky-blue focus:outline-none"
                                 ),
                             ]),
-                            fieldHint(h, "No email? Check your spam folder"),
+                            fieldHint(h, msgs.codeHint),
                         ]
                     ),
-                    errorBox(h, wizard.verifyError),
+                    errorBox(
+                        h,
+                        Option.map(wizard.verifyError, (key) => msgs.errors[key])
+                    ),
                     h.button(
                         [
                             h.Type("submit"),
                             h.Disabled(wizard.submitting || wizard.verified),
                             h.Class(submitButtonClass),
                         ],
-                        [
-                            wizard.verified
-                                ? "Linked! Redirecting..."
-                                : wizard.submitting
-                                  ? "Verifying..."
-                                  : "Link My Tower",
-                        ]
+                        [wizard.verified ? msgs.linked : wizard.submitting ? msgs.verifying : msgs.linkMyTower]
                     ),
                 ]
             ),
@@ -396,7 +392,7 @@ const verifyStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
                             h.OnClick(ClickedBack()),
                             h.Class("font-mono text-sky-dark cursor-pointer text-lg hover:underline"),
                         ],
-                        ["← Go back"]
+                        [msgs.goBack]
                     ),
                     h.button(
                         [
@@ -407,29 +403,26 @@ const verifyStep = (wizard: WizardModel, h: HtmlBuilder<AppMessage>): Html =>
                                 "font-mono text-sky-dark cursor-pointer text-lg hover:underline disabled:cursor-not-allowed"
                             ),
                         ],
-                        [wizard.resend === "sent" ? "Sent!" : "Resend email"]
+                        [wizard.resend === "sent" ? msgs.sent : msgs.resend]
                     ),
                 ]
             ),
         ]
     );
 
-export const towerLinkView = (h: HtmlBuilder<AppMessage>, wizard: WizardModel): Html =>
+export const towerLinkView = (h: HtmlBuilder<AppMessage>, msgs: TowerLinkMessages, wizard: WizardModel): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center justify-center p-8")],
         [
-            appBackLink(h, "/towers/@me", "← My Towers"),
+            appBackLink(h, "/towers/@me", msgs.backToTowers),
             h.div(
                 [h.Class("bg-card-bg shadow-pixel-hover border-gold w-full max-w-md rounded-2xl border-3 p-8")],
                 [
                     h.div(
                         [h.Class("mb-6 text-center")],
                         [
-                            h.h1([h.Class("font-pixel mb-2 text-lg text-gray-800")], ["Link Your Tower"]),
-                            h.p(
-                                [h.Class("font-mono text-xl text-gray-600")],
-                                ["Connect your TinyTower cloud save to start trading with players worldwide"]
-                            ),
+                            h.h1([h.Class("font-pixel mb-2 text-lg text-gray-800")], [msgs.heading]),
+                            h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.subheading]),
                         ]
                     ),
                     h.div(
@@ -438,7 +431,7 @@ export const towerLinkView = (h: HtmlBuilder<AppMessage>, wizard: WizardModel): 
                             h.div([h.Class("bg-gold h-2 flex-1 rounded-full"), h.AriaHidden(true)], []),
                             h.span(
                                 [h.Class("font-pixel shrink-0 text-[0.55rem] text-gray-500")],
-                                [wizard.step === "link" ? "Step 1 of 2" : "Step 2 of 2"]
+                                [wizard.step === "link" ? msgs.step1 : msgs.step2]
                             ),
                             h.div(
                                 [
@@ -451,7 +444,7 @@ export const towerLinkView = (h: HtmlBuilder<AppMessage>, wizard: WizardModel): 
                             ),
                         ]
                     ),
-                    wizard.step === "link" ? linkStep(wizard, h) : verifyStep(wizard, h),
+                    wizard.step === "link" ? linkStep(wizard, msgs, h) : verifyStep(wizard, msgs, h),
                 ]
             ),
         ]

--- a/apps/tinyburg.app/client/pages/towerMe.ts
+++ b/apps/tinyburg.app/client/pages/towerMe.ts
@@ -1,8 +1,10 @@
-import { DateTime, Option } from "effect";
+import { type DateTime, Option } from "effect";
 
 import type { LinkedTowers, SessionUser } from "../backend.ts";
+import type { SharedMessages, TowerMeMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
+import { type Language, longDate } from "@tinyburg/ui/Internationalization";
 import { AsyncData } from "foldkit";
 
 import { appBackLink } from "../ui/chrome.ts";
@@ -31,12 +33,12 @@ const navRow = <M>(h: HtmlBuilder<M>, href: string, emoji: string, title: string
         ]
     );
 
-const avatar = <M>(h: HtmlBuilder<M>, user: SessionUser): Html =>
+const avatar = <M>(h: HtmlBuilder<M>, msgs: TowerMeMessages, user: SessionUser): Html =>
     Option.match(user.avatarUrl, {
         onSome: (avatarUrl) =>
             h.img([
                 h.Src(avatarUrl),
-                h.Alt(`Avatar for ${user.displayName}`),
+                h.Alt(msgs.avatarAlt(user.displayName)),
                 h.Referrerpolicy("no-referrer"),
                 h.Class("h-16 w-16 shrink-0 rounded-lg border-2 border-gray-300 bg-white object-cover"),
             ]),
@@ -53,7 +55,7 @@ const avatar = <M>(h: HtmlBuilder<M>, user: SessionUser): Html =>
     });
 
 /** The linked towers section, driven by the trading api. */
-const towerList = <M>(h: HtmlBuilder<M>, towers: LinkedTowers): Html => {
+const towerList = <M>(h: HtmlBuilder<M>, msgs: TowerMeMessages, language: Language, towers: LinkedTowers): Html => {
     const empty = (message: string, detail: string): Html =>
         h.div(
             [h.Class("rounded-lg border-2 border-dashed border-gray-300 p-8 text-center")],
@@ -66,10 +68,7 @@ const towerList = <M>(h: HtmlBuilder<M>, towers: LinkedTowers): Html => {
 
     const linked = (data: ReadonlyArray<{ readonly playerId: string; readonly createdAt: DateTime.Utc }>): Html =>
         data.length === 0
-            ? empty(
-                  "No towers linked yet",
-                  "Link your TinyTower save to sync your bitizens and start trading with players worldwide."
-              )
+            ? empty(msgs.noTowers, msgs.noTowersDetailLong)
             : h.div(
                   [h.Class("flex flex-col gap-4")],
                   data.map((tower) =>
@@ -80,14 +79,7 @@ const towerList = <M>(h: HtmlBuilder<M>, towers: LinkedTowers): Html => {
                               h.div([h.Class("font-mono text-2xl tracking-[0.2em] text-gray-800")], [tower.playerId]),
                               h.div(
                                   [h.Class("font-mono text-base text-gray-500")],
-                                  [
-                                      `Linked ${DateTime.format(tower.createdAt, {
-                                          locale: "en-US",
-                                          month: "long",
-                                          day: "numeric",
-                                          year: "numeric",
-                                      })}`,
-                                  ]
+                                  [msgs.linkedOn(longDate(language, tower.createdAt))]
                               ),
                           ]
                       )
@@ -95,20 +87,27 @@ const towerList = <M>(h: HtmlBuilder<M>, towers: LinkedTowers): Html => {
               );
 
     return AsyncData.match(towers, {
-        onIdle: () => empty("No towers linked yet", "Link your TinyTower save to start trading."),
-        onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading your towers..."]),
-        onFailure: (error) => h.p([h.Class("font-mono text-xl text-red-700")], [error]),
+        onIdle: () => empty(msgs.noTowers, msgs.noTowersDetailShort),
+        onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loadingTowers]),
+        onFailure: () => h.p([h.Class("font-mono text-xl text-red-700")], [msgs.towersLoadFailed]),
         onRefreshing: linked,
         onStale: ({ data }) => linked(data),
         onSuccess: linked,
     });
 };
 
-export const towerMeView = <M>(h: HtmlBuilder<M>, user: SessionUser, towers: LinkedTowers): Html => {
+export const towerMeView = <M>(
+    h: HtmlBuilder<M>,
+    msgs: TowerMeMessages,
+    shared: SharedMessages,
+    language: Language,
+    user: SessionUser,
+    towers: LinkedTowers
+): Html => {
     return h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center p-8 pt-24")],
         [
-            appBackLink(h, "/", "← Back to Home"),
+            appBackLink(h, "/", shared.backToHome),
             h.div(
                 [h.Class("flex w-full max-w-2xl flex-col gap-6")],
                 [
@@ -118,7 +117,7 @@ export const towerMeView = <M>(h: HtmlBuilder<M>, user: SessionUser, towers: Lin
                             h.div(
                                 [h.Class("flex flex-wrap items-center gap-4")],
                                 [
-                                    avatar(h, user),
+                                    avatar(h, msgs, user),
                                     h.div(
                                         [h.Class("min-w-0 flex-1")],
                                         [
@@ -126,7 +125,7 @@ export const towerMeView = <M>(h: HtmlBuilder<M>, user: SessionUser, towers: Lin
                                                 [h.Class("font-pixel mb-2 text-lg wrap-break-word text-gray-800")],
                                                 [user.displayName]
                                             ),
-                                            h.p([h.Class("font-mono text-xl text-gray-600")], ["🏙️ Mayor of Tinyburg"]),
+                                            h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.mayor]),
                                         ]
                                     ),
                                     // A native form because signing out is a POST: the
@@ -146,7 +145,7 @@ export const towerMeView = <M>(h: HtmlBuilder<M>, user: SessionUser, towers: Lin
                                                         "font-pixel bg-dark-blue/80 shadow-pixel hover:shadow-pixel-hover cursor-pointer rounded px-4 py-3 text-[0.7rem] text-white transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                                     ),
                                                 ],
-                                                ["Sign Out"]
+                                                [msgs.signOut]
                                             ),
                                         ]
                                     ),
@@ -160,7 +159,7 @@ export const towerMeView = <M>(h: HtmlBuilder<M>, user: SessionUser, towers: Lin
                             h.div(
                                 [h.Class("mb-6 flex items-center justify-between gap-4")],
                                 [
-                                    h.h2([h.Class("font-pixel text-lg text-gray-800")], ["My Towers"]),
+                                    h.h2([h.Class("font-pixel text-lg text-gray-800")], [msgs.towersHeading]),
                                     h.a(
                                         [
                                             h.Href("/towers/@link"),
@@ -168,27 +167,15 @@ export const towerMeView = <M>(h: HtmlBuilder<M>, user: SessionUser, towers: Lin
                                                 "bg-gold shadow-pixel hover:shadow-pixel-hover font-pixel shrink-0 rounded-lg px-4 py-3 text-[0.7rem] text-gray-800 no-underline transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                             ),
                                         ],
-                                        ["+ Link a Tower"]
+                                        [msgs.linkATower]
                                     ),
                                 ]
                             ),
-                            towerList(h, towers),
+                            towerList(h, msgs, language, towers),
                         ]
                     ),
-                    navRow(
-                        h,
-                        "/account",
-                        "🔐",
-                        "Account & Security",
-                        "Manage where you're signed in and how you sign in"
-                    ),
-                    navRow(
-                        h,
-                        "/developers/apps",
-                        "🛠️",
-                        "Developer Portal",
-                        "Register OAuth apps that sign users in with Tinyburg"
-                    ),
+                    navRow(h, "/account", "🔐", msgs.accountRow.title, msgs.accountRow.detail),
+                    navRow(h, "/developers/apps", "🛠️", msgs.developerRow.title, msgs.developerRow.detail),
                 ]
             ),
         ]

--- a/apps/tinyburg.app/test/pages/account.test.ts
+++ b/apps/tinyburg.app/test/pages/account.test.ts
@@ -4,10 +4,12 @@ import type { SessionUser } from "../../client/backend.ts";
 import type { Message as AppMessage } from "../../client/main.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
+import { relativeTime } from "@tinyburg/ui/Internationalization";
 import { AsyncData } from "foldkit";
 import { Scene } from "foldkit/test";
 import { describe, it } from "vitest";
 
+import { en } from "../../client/messages/en.ts";
 import {
     AccountMessage,
     type AccountModel,
@@ -32,6 +34,13 @@ const { all, click, Command, expect, expectAll, given, role, scene, text, title 
 
 // FIXTURES
 
+/*
+  Selectors go through the `en` messages module (and the shared date
+  formatters) rather than repeating the copy, so a wording edit fails in
+  exactly one place.
+*/
+const msgs = en.account;
+
 const user: SessionUser = {
     id: "00000000-0000-4000-8000-000000000001",
     createdAt: DateTime.makeUnsafe("2026-01-04T09:00:00Z"),
@@ -52,6 +61,9 @@ const hoursBefore = (hours: number): DateTime.Utc =>
 const CHROME_MACOS =
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 const FIREFOX_WINDOWS = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:126.0) Gecko/20100101 Firefox/126.0";
+
+const chromeOnMacos = msgs.deviceOn("Chrome", "macOS");
+const firefoxOnWindows = msgs.deviceOn("Firefox", "Windows");
 
 const thisDevice = {
     id: "11111111-1111-4111-8111-111111111111",
@@ -128,7 +140,7 @@ const page = {
         }
         return updateAccount(model, message);
     },
-    view: (model: AccountModel, h: HtmlBuilder<AppMessage>): Html => accountView(h, model, user),
+    view: (model: AccountModel, h: HtmlBuilder<AppMessage>): Html => accountView(h, msgs, "en", model, user),
 };
 
 describe("account page", () => {
@@ -137,7 +149,7 @@ describe("account page", () => {
             scene(
                 page,
                 given(arrivingWith(Option.some("linked"), Option.none())),
-                expect(text("Connected. You can now sign in with it.")).toExist()
+                expect(text(msgs.notices.connected)).toExist()
             );
         });
 
@@ -145,7 +157,7 @@ describe("account page", () => {
             scene(
                 page,
                 given(arrivingWith(Option.none(), Option.some("oauth_denied"))),
-                expect(text("Connecting that account was cancelled.")).toExist()
+                expect(text(msgs.notices.linkCancelled)).toExist()
             );
         });
 
@@ -153,7 +165,7 @@ describe("account page", () => {
             scene(
                 page,
                 given(arrivingWith(Option.some("taken"), Option.none())),
-                expect(text("That account is already connected to a different Tinyburg account.")).toExist()
+                expect(text(msgs.problems.accountTaken)).toExist()
             );
         });
 
@@ -166,7 +178,7 @@ describe("account page", () => {
             scene(
                 page,
                 given(arrivingWith(Option.some("something_new"), Option.none())),
-                expect(text("Where You're Signed In")).toExist(),
+                expect(text(msgs.sessionsHeading)).toExist(),
                 expectAll(all.role("status")).toBeEmpty()
             );
         });
@@ -177,9 +189,9 @@ describe("account page", () => {
             scene(
                 page,
                 given(loaded([thisDevice, otherDevice], [googleAccount, discordAccount])),
-                expect(text("Chrome on macOS")).toExist(),
-                expect(text("This device")).toExist(),
-                expect(text("Firefox on Windows")).toExist()
+                expect(text(chromeOnMacos)).toExist(),
+                expect(text(msgs.thisDevice)).toExist(),
+                expect(text(firefoxOnWindows)).toExist()
             );
         });
 
@@ -187,8 +199,8 @@ describe("account page", () => {
             scene(
                 page,
                 given(loaded([thisDevice, otherDevice], [googleAccount])),
-                expect(text("Last active just now · 203.0.113.7")).toExist(),
-                expect(text("Last active 2 hours ago")).toExist()
+                expect(text(`${msgs.lastActive(relativeTime("en", now, now))} · 203.0.113.7`)).toExist(),
+                expect(text(msgs.lastActive(relativeTime("en", now, hoursBefore(2))))).toExist()
             );
         });
 
@@ -196,13 +208,13 @@ describe("account page", () => {
             scene(
                 page,
                 given(loaded([thisDevice], [googleAccount])),
-                expect(role("button", { name: "No other sessions" })).toBeDisabled()
+                expect(role("button", { name: msgs.noOtherSessions })).toBeDisabled()
             );
 
             scene(
                 page,
                 given(loaded([thisDevice, otherDevice], [googleAccount])),
-                expect(role("button", { name: "Sign out 1 other session" })).toBeEnabled()
+                expect(role("button", { name: msgs.signOutOthers(1) })).toBeEnabled()
             );
         });
     });
@@ -218,23 +230,23 @@ describe("account page", () => {
             scene(
                 page,
                 given(loaded([thisDevice, otherDevice], [googleAccount])),
-                click(title("Sign out of Firefox on Windows")),
+                click(title(msgs.signOutOf(firefoxOnWindows))),
 
                 Command.expectExact({ name: "RevokeSession", args: { sessionId: otherDevice.id } }),
 
-                expect(title("Sign out of Firefox on Windows")).toHaveText("..."),
-                expect(title("Sign out of Firefox on Windows")).toBeDisabled(),
-                expect(title("Sign out of this browser")).toHaveText("Sign out"),
-                expect(title("Sign out of this browser")).toBeEnabled(),
+                expect(title(msgs.signOutOf(firefoxOnWindows))).toHaveText("..."),
+                expect(title(msgs.signOutOf(firefoxOnWindows))).toBeDisabled(),
+                expect(title(msgs.signOutThisBrowser)).toHaveText(msgs.signOut),
+                expect(title(msgs.signOutThisBrowser)).toBeEnabled(),
 
                 Command.resolveAll(
                     [RevokeSession, CompletedRevoke({ revoked: 1, signedOut: false })],
                     [FetchSessions, SettledSessions({ result: Result.succeed([thisDevice]), asOf: now })]
                 ),
 
-                expect(text("Signed out of 1 session.")).toExist(),
-                expect(text("Firefox on Windows")).toBeAbsent(),
-                expect(role("button", { name: "No other sessions" })).toBeDisabled()
+                expect(text(msgs.signedOutSessions(1))).toExist(),
+                expect(text(firefoxOnWindows)).toBeAbsent(),
+                expect(role("button", { name: msgs.noOtherSessions })).toBeDisabled()
             );
         });
 
@@ -242,12 +254,12 @@ describe("account page", () => {
             scene(
                 page,
                 given(loaded([thisDevice, otherDevice], [googleAccount])),
-                click(role("button", { name: "Sign out 1 other session" })),
+                click(role("button", { name: msgs.signOutOthers(1) })),
                 Command.resolveAll(
                     [RevokeOthers, CompletedRevoke({ revoked: 3, signedOut: false })],
                     [FetchSessions, SettledSessions({ result: Result.succeed([thisDevice]), asOf: now })]
                 ),
-                expect(text("Signed out of 3 sessions.")).toExist()
+                expect(text(msgs.signedOutSessions(3))).toExist()
             );
         });
 
@@ -260,10 +272,10 @@ describe("account page", () => {
             scene(
                 page,
                 given(loaded([thisDevice, otherDevice], [googleAccount])),
-                click(role("button", { name: "Sign out everywhere" })),
+                click(role("button", { name: msgs.signOutEverywhere })),
                 Command.resolveAll([RevokeAll, CompletedRevoke({ revoked: 2, signedOut: true })]),
                 Command.expectNone(),
-                expect(text("Signed out of 2 sessions.")).toBeAbsent()
+                expect(text(msgs.signedOutSessions(2))).toBeAbsent()
             );
         });
 
@@ -271,10 +283,10 @@ describe("account page", () => {
             scene(
                 page,
                 given(loaded([thisDevice, otherDevice], [googleAccount])),
-                click(title("Sign out of Firefox on Windows")),
-                Command.resolveAll([RevokeSession, FailedAction({ message: "That didn't work. Please try again." })]),
-                expect(text("That didn't work. Please try again.")).toExist(),
-                expect(title("Sign out of Firefox on Windows")).toBeEnabled()
+                click(title(msgs.signOutOf(firefoxOnWindows))),
+                Command.resolveAll([RevokeSession, FailedAction({ problem: "actionFailed" })]),
+                expect(text(msgs.problems.actionFailed)).toExist(),
+                expect(title(msgs.signOutOf(firefoxOnWindows))).toBeEnabled()
             );
         });
     });
@@ -298,7 +310,7 @@ describe("account page", () => {
             scene(
                 page,
                 given(loaded([thisDevice], [googleAccount])),
-                expect(title("This is the only way you have left to sign in")).toBeDisabled()
+                expect(title(msgs.lastMethodTitle)).toBeDisabled()
             );
         });
 
@@ -306,8 +318,8 @@ describe("account page", () => {
             scene(
                 page,
                 given(loaded([thisDevice], [googleAccount, discordAccount])),
-                expect(title("Disconnect Google")).toBeEnabled(),
-                click(title("Disconnect Google")),
+                expect(title(msgs.disconnectProvider("Google"))).toBeEnabled(),
+                click(title(msgs.disconnectProvider("Google"))),
 
                 Command.expectExact({
                     name: "Unlink",
@@ -319,15 +331,15 @@ describe("account page", () => {
                     [FetchLinkedAccounts, SettledLinkedAccounts({ result: Result.succeed([discordAccount]) })]
                 ),
 
-                expect(text("Disconnected.")).toExist(),
-                expect(title("This is the only way you have left to sign in")).toBeDisabled()
+                expect(text(msgs.notices.disconnected)).toExist(),
+                expect(title(msgs.lastMethodTitle)).toBeDisabled()
             );
         });
     });
 
     describe("loading and failure", () => {
         it("says it is loading before anything has landed", () => {
-            scene(page, given({ ...initialAccount, asOf: now }), expect(text("Loading your sessions...")).toExist());
+            scene(page, given({ ...initialAccount, asOf: now }), expect(text(msgs.loadingSessions)).toExist());
         });
 
         it("shows the failure text in place of the list", () => {
@@ -336,10 +348,10 @@ describe("account page", () => {
                 given({
                     ...initialAccount,
                     asOf: now,
-                    sessions: AsyncData.fail("We couldn't load this. Please try again."),
+                    sessions: AsyncData.fail("loadFailed"),
                 }),
-                expect(text("We couldn't load this. Please try again.")).toExist(),
-                expect(role("button", { name: "Sign out everywhere" })).toBeAbsent()
+                expect(text(msgs.loadFailed)).toExist(),
+                expect(role("button", { name: msgs.signOutEverywhere })).toBeAbsent()
             );
         });
 
@@ -352,11 +364,11 @@ describe("account page", () => {
             scene(
                 page,
                 given(loaded([thisDevice, otherDevice], [googleAccount])),
-                click(role("button", { name: "Sign out 1 other session" })),
+                click(role("button", { name: msgs.signOutOthers(1) })),
                 Command.resolveAll([RevokeOthers, CompletedRevoke({ revoked: 1, signedOut: false })]),
 
-                expect(text("Chrome on macOS")).toExist(),
-                expect(text("Firefox on Windows")).toExist(),
+                expect(text(chromeOnMacos)).toExist(),
+                expect(text(firefoxOnWindows)).toExist(),
 
                 Command.resolve(FetchSessions, SettledSessions({ result: Result.succeed([thisDevice]), asOf: now }))
             );

--- a/apps/tinyburg.app/test/pages/home.i18n.test.ts
+++ b/apps/tinyburg.app/test/pages/home.i18n.test.ts
@@ -1,0 +1,36 @@
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+import { Scene } from "foldkit/test";
+import { describe, it } from "vitest";
+
+import { messagesFor } from "../../client/messages/index.ts";
+import { homeView } from "../../client/pages/home.ts";
+
+/*
+  Renders the home page with the German messages and asserts the German copy
+  lands in the tree. This proves the msgs slices actually thread through the
+  view (not that the translation is any good); the per-page behaviour tests
+  keep selecting through `en`.
+*/
+const de = messagesFor("de");
+const en = messagesFor("en");
+
+const page = {
+    update: (model: null, _message: never): readonly [null, ReadonlyArray<never>] => [model, []],
+    view: (_model: null, h: HtmlBuilder<never>): Html => homeView(h, de.home, de.shared),
+};
+
+const { expect, given, role, scene, text } = Scene;
+
+describe("home page rendered in German", () => {
+    it("shows the German copy where the English copy would be", () => {
+        scene(
+            page,
+            given(null),
+            expect(role("heading", { name: de.home.featuresHeading })).toExist(),
+            expect(role("heading", { name: en.home.featuresHeading })).toBeAbsent(),
+            expect(role("link", { name: de.home.startTrading })).toHaveAttr("href", "/login"),
+            expect(text(de.home.copyright)).toExist()
+        );
+    });
+});

--- a/apps/tinyburg.app/test/pages/login.test.ts
+++ b/apps/tinyburg.app/test/pages/login.test.ts
@@ -5,12 +5,16 @@ import type { Html, HtmlBuilder } from "foldkit/html";
 import { Scene } from "foldkit/test";
 import { describe, it } from "vitest";
 
+import { en } from "../../client/messages/en.ts";
 import { loginView } from "../../client/pages/login.ts";
 
 /*
   The login page is a pure view: every affordance on it is a server round trip
   behind an `<a href>`, so there are no Messages and update never runs. The
   Model is only what `main.ts` reads out of the url and hands to `loginView`.
+
+  Selectors go through the `en` messages module rather than repeating the
+  copy, so an edit to the wording fails in exactly one place.
 */
 type Model = Readonly<{
     returnTo: Option.Option<string>;
@@ -19,7 +23,7 @@ type Model = Readonly<{
 
 const page = {
     update: (model: Model, _message: never): readonly [Model, ReadonlyArray<never>] => [model, []],
-    view: (model: Model, h: HtmlBuilder<never>): Html => loginView(h, model.returnTo, model.error),
+    view: (model: Model, h: HtmlBuilder<never>): Html => loginView(h, en.login, en.shared, model.returnTo, model.error),
 };
 
 const arriving: Model = { returnTo: Option.none(), error: Option.none() };
@@ -33,9 +37,9 @@ describe("login page", () => {
         scene(
             page,
             given(arriving),
-            expect(role("heading", { name: "Welcome to Tinyburg" })).toExist(),
-            expect(role("link", { name: "Continue with Google" })).toHaveAttr("href", "/auth/google/login"),
-            expect(role("link", { name: "Continue with Discord" })).toHaveAttr("href", "/auth/discord/login"),
+            expect(role("heading", { name: en.login.heading })).toExist(),
+            expect(role("link", { name: en.login.continueWithGoogle })).toHaveAttr("href", "/auth/google/login"),
+            expect(role("link", { name: en.login.continueWithDiscord })).toHaveAttr("href", "/auth/discord/login"),
             expect(role("status")).toBeAbsent(),
             expect(role("alert")).toBeAbsent()
         );
@@ -45,11 +49,11 @@ describe("login page", () => {
         scene(
             page,
             given({ ...arriving, returnTo: Option.some("/towers/@me") }),
-            expect(role("link", { name: "Continue with Google" })).toHaveAttr(
+            expect(role("link", { name: en.login.continueWithGoogle })).toHaveAttr(
                 "href",
                 "/auth/google/login?returnTo=%2Ftowers%2F%40me"
             ),
-            expect(role("link", { name: "Continue with Discord" })).toHaveAttr(
+            expect(role("link", { name: en.login.continueWithDiscord })).toHaveAttr(
                 "href",
                 "/auth/discord/login?returnTo=%2Ftowers%2F%40me"
             )
@@ -66,7 +70,7 @@ describe("login page", () => {
         scene(
             page,
             given(withError("oauth_denied")),
-            expect(role("status")).toContainText("Sign in was cancelled"),
+            expect(role("status")).toContainText(en.login.problems.denied),
             expect(role("alert")).toBeAbsent()
         );
     });
@@ -77,8 +81,7 @@ describe("login page", () => {
             scene(
                 page,
                 given(withError(code)),
-                expect(role("alert")).toContainText("expired or was interrupted"),
-                expect(role("alert")).toContainText("allows cookies"),
+                expect(role("alert")).toContainText(en.login.problems.expired),
                 expect(role("status")).toBeAbsent()
             );
         }
@@ -93,7 +96,7 @@ describe("login page", () => {
         scene(
             page,
             given(withError("some_code_nobody_has_written_yet")),
-            expect(role("alert")).toHaveText("We couldn't finish signing you in. Please try again."),
+            expect(role("alert")).toHaveText(en.login.problems.failed),
             expect(role("status")).toBeAbsent()
         );
     });
@@ -102,8 +105,8 @@ describe("login page", () => {
         scene(
             page,
             given(arriving),
-            expect(text("Terms of Service")).toHaveAttr("href", "/terms"),
-            expect(text("Privacy Policy")).toHaveAttr("href", "/privacy")
+            expect(text(en.login.termsOfService)).toHaveAttr("href", "/terms"),
+            expect(text(en.login.privacyPolicy)).toHaveAttr("href", "/privacy")
         );
     });
 });


### PR DESCRIPTION
Stacked on #98. Elm-style typed message modules for the tinyburg.app client: one Messages interface, per-locale modules, missing keys are compile errors.

- client/messages/{types,en,de,es,fr,index}.ts, ~233 keys per locale; language in the Model, initialized from navigator.language
- msgs threaded through pageView, routeTitle, and every createLazy arg array (privacy/terms prose stays English, titles localized)
- Hand-rolled relative-time formatter replaced with relativeTime/longDate from @tinyburg/ui/Internationalization (minor en wording changes: "just now" becomes "now", "an hour ago" becomes "1 hour ago")
- Strings produced in update()/commands became typed tags resolved to copy at view time, keeping the model language-independent
- Scene tests now select via en.* fields; new de-render test proves threading
- 10 REVIEW comments mark translations needing human sign-off

