### PR TITLE
Localize the authproxy client (en/de/es/fr)

### DIFF
--- a/apps/authproxy/client/entry.ts
+++ b/apps/authproxy/client/entry.ts
@@ -3,7 +3,7 @@ import "./styles/global.css";
 import { Runtime } from "foldkit";
 
 import { BackendLive } from "./backend.ts";
-import { ChangedUrl, ClickedLink, Model, init, update, view } from "./main.ts";
+import { ChangedUrl, ClickedLink, init, initialLanguage, Model, update, view } from "./main.ts";
 
 const application = Runtime.makeApplication({
     Model,
@@ -17,5 +17,9 @@ const application = Runtime.makeApplication({
         onUrlChange: (url) => ChangedUrl({ url }),
     },
 });
+
+// index.html is served statically, so the document language can only be
+// corrected here, once the negotiated answer is known.
+document.documentElement.lang = initialLanguage;
 
 Runtime.run(application);

--- a/apps/authproxy/client/entry.ts
+++ b/apps/authproxy/client/entry.ts
@@ -3,7 +3,7 @@ import "./styles/global.css";
 import { Runtime } from "foldkit";
 
 import { BackendLive } from "./backend.ts";
-import { ChangedUrl, ClickedLink, init, initialLanguage, Model, update, view } from "./main.ts";
+import { ChangedUrl, ClickedLink, Model, init, initialLanguage, update, view } from "./main.ts";
 
 const application = Runtime.makeApplication({
     Model,

--- a/apps/authproxy/client/main.ts
+++ b/apps/authproxy/client/main.ts
@@ -3,7 +3,7 @@ import { Effect, Match, Option, Schema as S } from "effect";
 import type { TitleMessages } from "./messages/types.ts";
 import type { Document, Html, HtmlBuilder } from "foldkit/html";
 
-import { fromNavigator, Language } from "@tinyburg/ui/Internationalization";
+import { Language, fromNavigator } from "@tinyburg/ui/Internationalization";
 import { AsyncData, Command, Navigation, Render, type Runtime, Url } from "foldkit";
 import { m } from "foldkit/message";
 import { evo } from "foldkit/struct";

--- a/apps/authproxy/client/main.ts
+++ b/apps/authproxy/client/main.ts
@@ -1,12 +1,15 @@
 import { Effect, Match, Option, Schema as S } from "effect";
 
+import type { TitleMessages } from "./messages/types.ts";
 import type { Document, Html, HtmlBuilder } from "foldkit/html";
 
+import { fromNavigator, Language } from "@tinyburg/ui/Internationalization";
 import { AsyncData, Command, Navigation, Render, type Runtime, Url } from "foldkit";
 import { m } from "foldkit/message";
 import { evo } from "foldkit/struct";
 
 import { type Backend, CheckingSession, FetchSession, GotSession, SessionState, SignedOut } from "./backend.ts";
+import { messagesFor } from "./messages/index.ts";
 import {
     AdminMessage,
     AdminModel,
@@ -26,11 +29,21 @@ import { AppRoute, loginHref, urlToAppRoute } from "./routes.ts";
 
 export const Model = S.Struct({
     route: AppRoute,
+    language: Language,
     session: SessionState,
     keys: KeysModel,
     admin: AdminModel,
 });
 export type Model = typeof Model.Type;
+
+/**
+ * Negotiated once at boot: the browser's languages against the ones tinyburg
+ * speaks. Module scope so `entry.ts` can stamp `<html lang>` with the same
+ * answer; guarded so importing this module in tests never touches a browser.
+ */
+export const initialLanguage = fromNavigator(
+    typeof navigator === "undefined" ? [] : (navigator.languages ?? [navigator.language])
+);
 
 // MESSAGE
 
@@ -184,6 +197,7 @@ export const init: Runtime.RoutingApplicationInit<Model, Message, void, Backend>
         resetPageState(
             {
                 route,
+                language: initialLanguage,
                 session: CheckingSession(),
                 keys: initialKeys,
                 admin: initialAdmin,
@@ -196,31 +210,38 @@ export const init: Runtime.RoutingApplicationInit<Model, Message, void, Backend>
 
 // VIEW
 
-const routeTitle = (route: AppRoute): string =>
+const routeTitle = (route: AppRoute, titles: TitleMessages): string =>
     Match.value(route).pipe(
         Match.withReturnType<string>(),
         Match.tagsExhaustive({
-            Home: () => "Tinyburg Authproxy | API Keys for Nimblebit's Servers",
-            Login: () => "Sign In | Tinyburg Authproxy",
-            Keys: () => "Your API Keys | Tinyburg Authproxy",
-            Admin: () => "Admin | Tinyburg Authproxy",
-            NotFound: () => "Page Not Found | Tinyburg Authproxy",
+            Home: () => titles.home,
+            Login: () => titles.login,
+            Keys: () => titles.keys,
+            Admin: () => titles.admin,
+            NotFound: () => titles.notFound,
         })
     );
 
-const pageView = (model: Model, h: HtmlBuilder<Message>): Html =>
-    Match.value(model.route).pipe(
+const pageView = (model: Model, h: HtmlBuilder<Message>): Html => {
+    const msgs = messagesFor(model.language);
+
+    return Match.value(model.route).pipe(
         Match.withReturnType<Html>(),
         Match.tagsExhaustive({
-            Home: () => homeView(h, model.session),
-            Login: ({ error, returnTo }) => loginView(h, returnTo, error),
+            Home: () => homeView(h, msgs.home, model.session),
+            Login: ({ error, returnTo }) => loginView(h, msgs.login, msgs.shared, returnTo, error),
             // The gated page renders nothing until the session answer lands;
             // enterRoute has already sent a signed out visitor to login.
-            Keys: () => (model.session._tag === "SignedIn" ? keysView(h, model.keys, model.session.session) : h.empty),
-            Admin: () => (model.session._tag === "SignedIn" ? adminView(h, model.admin) : h.empty),
-            NotFound: () => notFoundView(h),
+            Keys: () =>
+                model.session._tag === "SignedIn"
+                    ? keysView(h, msgs.keys, msgs.shared, model.language, model.keys, model.session.session)
+                    : h.empty,
+            Admin: () =>
+                model.session._tag === "SignedIn" ? adminView(h, msgs.admin, msgs.shared, model.admin) : h.empty,
+            NotFound: () => notFoundView(h, msgs.notFound, msgs.shared),
         })
     );
+};
 
 /**
  * Keys the page wrapper so navigating replaces it outright rather than
@@ -232,6 +253,6 @@ const pageKey = (model: Model): string =>
         : model.route._tag;
 
 export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
-    title: routeTitle(model.route),
+    title: routeTitle(model.route, messagesFor(model.language).titles),
     body: h.div([], [h.keyed("div")(pageKey(model), [], [pageView(model, h)])]),
 });

--- a/apps/authproxy/client/messages/de.ts
+++ b/apps/authproxy/client/messages/de.ts
@@ -1,0 +1,146 @@
+/**
+ * German messages. Register: formal "Sie".
+ *
+ * Kept in English (glossary): Tinyburg, TinyTower, Nimblebit, Authproxy,
+ * bitizen(s), bux, Discord, and technical terms the API surface owns (scope,
+ * Bearer-Token, SDK, gzip). "Towers"/"floors"/"friends" translate normally.
+ */
+
+import type { Messages } from "./types.ts";
+
+export const de: Messages = {
+    titles: {
+        home: "Tinyburg Authproxy | API-Schlüssel für Nimblebits Server",
+        login: "Anmelden | Tinyburg Authproxy",
+        keys: "Ihre API-Schlüssel | Tinyburg Authproxy",
+        admin: "Admin | Tinyburg Authproxy",
+        notFound: "Seite nicht gefunden | Tinyburg Authproxy",
+    },
+    shared: {
+        backToHome: "← Zurück zur Startseite",
+        cancel: "Abbrechen",
+        delete: "Löschen",
+        rateLimit: (limit, windowSeconds) => `${limit} Anfragen / ${windowSeconds}s`,
+        reallyDelete: "Wirklich löschen?",
+        reEnable: "Reaktivieren",
+        revoke: "Widerrufen",
+        revokedBadge: "Widerrufen",
+    },
+    home: {
+        title: "Tinyburg Authproxy",
+        tagline: "Authentifizierter, ratenbegrenzter Zugriff auf Nimblebits TinyTower-Server.",
+        manageKeys: "Ihre API-Schlüssel verwalten →",
+        signIn: "Mit Tinyburg anmelden →",
+        howItWorksHeading: "So funktioniert es",
+        howItWorksIntro:
+            "Der Proxy signiert Ihre Anfragen, bevor er sie an Nimblebit weiterleitet; Sie kommen also nie mit Salts oder Hashes in Berührung. Authentifizieren Sie sich mit einem API-Schlüssel als Bearer-Token:",
+        howItWorksScopes:
+            "Ein Schlüssel trägt Scopes, einen je Endpunkt-Familie, und ein eigenes Rate-Limit. Melden Sie sich mit Ihrem Tinyburg-Konto an, um sich selbst Nur-Lese-Schlüssel auszustellen, Ihre Schlüssel einzusehen und geleakte zu rotieren.",
+        sdkHeading: "Das SDK verwenden",
+        sdkIntroBefore: "Dieser Proxy nutzt dieselben Endpunkt-Definitionen, aus denen ",
+        sdkIntroAfter:
+            " gebaut ist; ein typisierter TypeScript-Client ist also inklusive. Er dekodiert Spielstände, Freunde, Geschenke, Besuche und Verlosungen in echte Typen und weiß bereits, wie er sich hierher ausrichtet:",
+        // REVIEW: "Nimblebit soup" is playful in the original; kept the image.
+        sdkOutro:
+            "AUTH_KEY ist der Proxy-Schlüssel, den Sie hier ausgestellt haben; PLAYER_ID und PLAYER_AUTH_KEY benennen den Tower, in dessen Namen Sie handeln. Abgerufene Spielstände kommen als gezippte Nimblebit-Suppe zurück: Geben Sie sie an das SaveData-Schema des SDK, und Sie erhalten Stockwerke, Bitizens, Missionen und Freunde als gewöhnliche typisierte Werte.",
+        testKeysHeading: "Öffentliche Testschlüssel",
+        testKeysIntro:
+            "Zwei geteilte Schlüssel stehen zum Ausprobieren bereit. Sie sind pro IP-Adresse ratenbegrenzt:",
+        testKeysOutro:
+            "Persönliche Schlüssel sind stattdessen pro Schlüssel ratenbegrenzt und starten mit 10 Anfragen pro Minute. Sie brauchen Schreib-Scopes oder ein höheres Limit? Melden Sie sich auf Discord.",
+        footerBefore: "Teil von ",
+        footerAfter: ", nicht mit Nimblebit verbunden.",
+    },
+    login: {
+        heading: "Authproxy Self-Service",
+        subheading: "Ihr Tinyburg-Konto ist hier Ihre Identität: eine Anmeldung, kein neues Passwort.",
+        signInWithTinyburg: "Mit Tinyburg anmelden",
+        noAccountBefore: "Noch kein Tinyburg-Konto? ",
+        createAccountLink: "Erstellen Sie zuerst eines auf tinyburg.app",
+        noAccountAfter: ".",
+        cancelled: "Die Anmeldung wurde abgebrochen. Sie können jederzeit dort weitermachen, wo Sie aufgehört haben.",
+        interrupted:
+            "Dieser Anmeldeversuch ist abgelaufen oder wurde unterbrochen. Bitte beginnen Sie erneut und prüfen Sie, ob Ihr Browser Cookies für diese Seite zulässt.",
+        failed: "Ihre Anmeldung konnte nicht abgeschlossen werden. Bitte versuchen Sie es erneut.",
+    },
+    keys: {
+        heading: "Ihre API-Schlüssel",
+        headingFor: (name) => `API-Schlüssel von ${name}`,
+        signOut: "Abmelden",
+        sectionHeading: "Ihre API-Schlüssel",
+        sectionIntro:
+            "Rotieren Sie jeden Schlüssel, der geleakt sein könnte, und löschen Sie die, die Sie nicht mehr verwenden.",
+        loading: "Ihre Schlüssel werden geladen...",
+        loadFailed: "Ihre Schlüssel konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+        emptyState: "Noch keine Schlüssel. Erstellen Sie einen und rufen Sie den Proxy auf.",
+        newKey: "+ Neuer Schlüssel",
+        maxKeysTitle: (maxKeys) => `Jedes Konto darf höchstens ${maxKeys} Schlüssel halten`,
+        provisionTitle: "Einen neuen Schlüssel ausstellen",
+        copy: "Kopieren",
+        // REVIEW: "rotieren" as key-rotation jargon; "erneuern" would be plainer.
+        rotate: "Rotieren",
+        rotateTitle:
+            "Stellt einen neuen Schlüssel für diese Zeile aus; der alte Schlüssel funktioniert sofort nicht mehr",
+        createdLastUsed: (created, lastUsed) => `Erstellt am ${created} · Zuletzt verwendet am ${lastUsed}`,
+        descriptionLabel: "Wofür ist dieser Schlüssel?",
+        descriptionPlaceholder: "Optionale Beschreibung, z. B. mein Tower-Statistik-Bot",
+        readOnlyScopesLabel: "Nur-Lese-Scopes (mindestens einen wählen)",
+        writeScopesNote: "Schreib-Scopes werden von Hand vergeben; melden Sie sich auf Discord",
+        createKey: "Schlüssel erstellen",
+        notices: {
+            copied: "In Ihre Zwischenablage kopiert.",
+            created: "Schlüssel erstellt. Er funktioniert sofort.",
+            rotated:
+                "Schlüssel rotiert. Der alte Schlüssel funktionierte in dem Moment nicht mehr, als der neue ausgestellt wurde.",
+            revoked: "Schlüssel widerrufen. Anfragen damit schlagen jetzt fehl.",
+            reEnabled: "Schlüssel reaktiviert.",
+            deleted: "Schlüssel gelöscht.",
+        },
+        problems: {
+            actionFailed: "Das hat nicht geklappt. Bitte versuchen Sie es erneut.",
+            createRefused: (maxKeys) =>
+                `Diese Anfrage wurde abgelehnt. Schlüssel brauchen mindestens einen Scope, und jedes Konto darf höchstens ${maxKeys} Schlüssel halten.`,
+            clipboardFailed: "Ihre Zwischenablage war nicht erreichbar. Bitte versuchen Sie es erneut.",
+        },
+    },
+    admin: {
+        heading: "Admin",
+        yourKeysLink: "Ihre Schlüssel",
+        // REVIEW: "step up" rendered as raising privileges; no snappy German idiom.
+        stepUpHeading: "Berechtigung erhöhen",
+        stepUpIntro:
+            "Admin-Aktionen brauchen mehr als eine Session: Sie geben das Admin-Passwort ein und autorisieren sich dann erneut bei Tinyburg, damit der Proxy, mit Ihrer Zustimmung, prüfen kann, ob Ihr Konto einen freigeschalteten Tower hält. Die Erhöhung gilt eine Stunde.",
+        passwordPlaceholder: "Admin-Passwort",
+        // REVIEW: mirrors "Elevate with Tinyburg"; reads unusual in German too.
+        elevate: "Mit Tinyburg erhöhen",
+        allKeysHeading: "Alle Schlüssel",
+        allKeysIntro:
+            "Jeder Schlüssel, den der Proxy ausgestellt hat, egal wer ihn hält. Schreib-Scopes werden hier vergeben.",
+        loading: "Wird geladen...",
+        loadFailed: "Die Schlüssel konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+        emptyState: "Es gibt noch keine Schlüssel.",
+        owner: (sub) => `Inhaber ${sub}`,
+        noOwner: "Kein Inhaber (von Admins ausgestellt)",
+        scopesButton: "Scopes",
+        rateLimitButton: "Rate-Limit",
+        saveScopes: "Scopes speichern",
+        saveLimit: "Limit speichern",
+        requestsLabel: "Anfragen",
+        // REVIEW: matches the quirky English "per seconds" next to the window field.
+        perSecondsLabel: "pro Sekunden",
+        notices: {
+            saved: "Gespeichert.",
+            keyDeleted: "Schlüssel gelöscht.",
+        },
+        problems: {
+            elevationFailed:
+                "Die Erhöhung wurde abgelehnt. Prüfen Sie das Passwort, dass Sie die Tower-Prüfung bestätigt haben und dass Ihr Konto einen freigeschalteten Tower hält.",
+            actionFailed: "Das hat nicht geklappt. Bitte versuchen Sie es erneut.",
+            rateLimitInvalid: "Rate-Limits brauchen positive ganze Zahlen.",
+        },
+    },
+    notFound: {
+        heading: "404",
+        body: "Dieses Stockwerk wurde noch nicht gebaut.",
+    },
+};

--- a/apps/authproxy/client/messages/de.ts
+++ b/apps/authproxy/client/messages/de.ts
@@ -44,8 +44,7 @@ export const de: Messages = {
         sdkOutro:
             "AUTH_KEY ist der Proxy-Schlüssel, den Sie hier ausgestellt haben; PLAYER_ID und PLAYER_AUTH_KEY benennen den Tower, in dessen Namen Sie handeln. Abgerufene Spielstände kommen als gezippte Nimblebit-Suppe zurück: Geben Sie sie an das SaveData-Schema des SDK, und Sie erhalten Stockwerke, Bitizens, Missionen und Freunde als gewöhnliche typisierte Werte.",
         testKeysHeading: "Öffentliche Testschlüssel",
-        testKeysIntro:
-            "Zwei geteilte Schlüssel stehen zum Ausprobieren bereit. Sie sind pro IP-Adresse ratenbegrenzt:",
+        testKeysIntro: "Zwei geteilte Schlüssel stehen zum Ausprobieren bereit. Sie sind pro IP-Adresse ratenbegrenzt:",
         testKeysOutro:
             "Persönliche Schlüssel sind stattdessen pro Schlüssel ratenbegrenzt und starten mit 10 Anfragen pro Minute. Sie brauchen Schreib-Scopes oder ein höheres Limit? Melden Sie sich auf Discord.",
         footerBefore: "Teil von ",

--- a/apps/authproxy/client/messages/en.ts
+++ b/apps/authproxy/client/messages/en.ts
@@ -1,0 +1,133 @@
+/**
+ * English messages, moved verbatim from the pages. The explicit `: Messages`
+ * annotation is what turns a missing key in any locale into a compile error.
+ */
+
+import type { Messages } from "./types.ts";
+
+export const en: Messages = {
+    titles: {
+        home: "Tinyburg Authproxy | API Keys for Nimblebit's Servers",
+        login: "Sign In | Tinyburg Authproxy",
+        keys: "Your API Keys | Tinyburg Authproxy",
+        admin: "Admin | Tinyburg Authproxy",
+        notFound: "Page Not Found | Tinyburg Authproxy",
+    },
+    shared: {
+        backToHome: "← Back to Home",
+        cancel: "Cancel",
+        delete: "Delete",
+        rateLimit: (limit, windowSeconds) => `${limit} requests / ${windowSeconds}s`,
+        reallyDelete: "Really delete?",
+        reEnable: "Re-enable",
+        revoke: "Revoke",
+        revokedBadge: "Revoked",
+    },
+    home: {
+        title: "Tinyburg Authproxy",
+        tagline: "Authenticated, rate-limited access to Nimblebit's TinyTower servers.",
+        manageKeys: "Manage your API keys →",
+        signIn: "Sign in with Tinyburg →",
+        howItWorksHeading: "How it works",
+        howItWorksIntro:
+            "The proxy signs your requests before forwarding them to Nimblebit, so you never touch salts or hashes. Authenticate with an API key as a bearer token:",
+        howItWorksScopes:
+            "A key carries scopes, one per endpoint family, and its own rate limit. Sign in with your Tinyburg account to provision read-only keys yourself, see the keys you hold, and rotate any that leak.",
+        sdkHeading: "Use the SDK",
+        sdkIntroBefore: "This proxy serves the same endpoint definitions that ",
+        sdkIntroAfter:
+            " is built from, so a typed TypeScript client comes for free. It decodes save data, friends, gifts, visits and raffles into real types, and it already knows how to aim itself here:",
+        sdkOutro:
+            "AUTH_KEY is the proxy key you provisioned here; PLAYER_ID and PLAYER_AUTH_KEY name the tower you are acting as. Pulled saves come back as gzipped Nimblebit soup — hand them to the SDK's SaveData schema and you get floors, bitizens, missions and friends as ordinary typed values.",
+        testKeysHeading: "Public test keys",
+        testKeysIntro: "Two shared keys exist for kicking the tires. They are rate limited by IP address:",
+        testKeysOutro:
+            "Personal keys are rate limited per key instead, and start at 10 requests a minute. Need write scopes or a higher limit? Reach out on Discord.",
+        footerBefore: "Part of ",
+        footerAfter: " — not affiliated with Nimblebit.",
+    },
+    login: {
+        heading: "Authproxy Self Service",
+        subheading: "Your Tinyburg account is your identity here — one sign in, no new password.",
+        signInWithTinyburg: "Sign in with Tinyburg",
+        noAccountBefore: "No Tinyburg account yet? ",
+        createAccountLink: "Create one at tinyburg.app",
+        noAccountAfter: " first.",
+        cancelled: "Sign in was cancelled. You can pick up where you left off whenever you like.",
+        interrupted:
+            "That sign in attempt expired or was interrupted. Please start again, and check that your browser allows cookies for this site.",
+        failed: "We couldn't finish signing you in. Please try again.",
+    },
+    keys: {
+        heading: "Your API keys",
+        headingFor: (name) => `${name}'s API keys`,
+        signOut: "Sign out",
+        sectionHeading: "Your API Keys",
+        sectionIntro: "Rotate any key you may have leaked, and delete the ones you no longer use.",
+        loading: "Loading your keys...",
+        loadFailed: "We couldn't load your keys. Please try again.",
+        emptyState: "No keys yet. Create one and start calling the proxy.",
+        newKey: "+ New key",
+        maxKeysTitle: (maxKeys) => `Each account may hold at most ${maxKeys} keys`,
+        provisionTitle: "Provision a new key",
+        copy: "Copy",
+        rotate: "Rotate",
+        rotateTitle: "Mint a new key for this row; the old key stops working immediately",
+        createdLastUsed: (created, lastUsed) => `Created ${created} · Last used ${lastUsed}`,
+        descriptionLabel: "What is this key for?",
+        descriptionPlaceholder: "Optional description, e.g. my tower stats bot",
+        readOnlyScopesLabel: "Read-only scopes (pick at least one)",
+        writeScopesNote: "Write scopes are granted by hand — reach out on Discord",
+        createKey: "Create key",
+        notices: {
+            copied: "Copied to your clipboard.",
+            created: "Key created. It works immediately.",
+            rotated: "Key rotated. The old key stopped working the moment the new one was minted.",
+            revoked: "Key revoked. Requests with it now fail.",
+            reEnabled: "Key re-enabled.",
+            deleted: "Key deleted.",
+        },
+        problems: {
+            actionFailed: "That didn't work. Please try again.",
+            createRefused: (maxKeys) =>
+                `That request was refused. Keys need at least one scope, and each account may hold at most ${maxKeys} keys.`,
+            clipboardFailed: "We couldn't reach your clipboard. Please try again.",
+        },
+    },
+    admin: {
+        heading: "Admin",
+        yourKeysLink: "Your keys",
+        stepUpHeading: "Step Up",
+        stepUpIntro:
+            "Admin actions need more than a session: you enter the admin password, then re-authorize with Tinyburg so the proxy can check - with your consent - that your account holds an allowlisted tower. Elevation lasts an hour.",
+        passwordPlaceholder: "Admin password",
+        elevate: "Elevate with Tinyburg",
+        allKeysHeading: "All Keys",
+        allKeysIntro: "Every key the proxy has issued, whoever holds it. Write scopes are granted here.",
+        loading: "Loading...",
+        loadFailed: "We couldn't load the keys. Please try again.",
+        emptyState: "No keys exist yet.",
+        owner: (sub) => `Owner ${sub}`,
+        noOwner: "No owner (admin-issued)",
+        scopesButton: "Scopes",
+        rateLimitButton: "Rate limit",
+        saveScopes: "Save scopes",
+        saveLimit: "Save limit",
+        requestsLabel: "Requests",
+        perSecondsLabel: "per seconds",
+        notices: {
+            saved: "Saved.",
+            keyDeleted: "Key deleted.",
+        },
+        problems: {
+            elevationFailed:
+                "Elevation was refused. Check the password, that you approved the tower check, and that your account holds an allowlisted tower.",
+            actionFailed: "That didn't work. Please try again.",
+            rateLimitInvalid: "Rate limits need positive whole numbers.",
+        },
+    },
+    notFound: {
+        heading: "404",
+        body: "This floor hasn't been built yet.",
+    },
+};

--- a/apps/authproxy/client/messages/es.ts
+++ b/apps/authproxy/client/messages/es.ts
@@ -1,0 +1,142 @@
+/**
+ * Spanish messages. Register: informal "tú".
+ *
+ * Kept in English (glossary): Tinyburg, TinyTower, Nimblebit, Authproxy,
+ * bitizen(s), bux, Discord, and technical terms the API surface owns (scope,
+ * token bearer, SDK, gzip). "Towers"/"floors"/"friends" translate normally.
+ */
+
+import type { Messages } from "./types.ts";
+
+export const es: Messages = {
+    titles: {
+        home: "Tinyburg Authproxy | Claves de API para los servidores de Nimblebit",
+        login: "Iniciar sesión | Tinyburg Authproxy",
+        keys: "Tus claves de API | Tinyburg Authproxy",
+        admin: "Admin | Tinyburg Authproxy",
+        notFound: "Página no encontrada | Tinyburg Authproxy",
+    },
+    shared: {
+        backToHome: "← Volver al inicio",
+        cancel: "Cancelar",
+        delete: "Eliminar",
+        rateLimit: (limit, windowSeconds) => `${limit} solicitudes / ${windowSeconds}s`,
+        reallyDelete: "¿Eliminar de verdad?",
+        reEnable: "Reactivar",
+        revoke: "Revocar",
+        revokedBadge: "Revocada",
+    },
+    home: {
+        title: "Tinyburg Authproxy",
+        tagline: "Acceso autenticado y con límite de solicitudes a los servidores de TinyTower de Nimblebit.",
+        manageKeys: "Gestiona tus claves de API →",
+        signIn: "Inicia sesión con Tinyburg →",
+        howItWorksHeading: "Cómo funciona",
+        howItWorksIntro:
+            "El proxy firma tus solicitudes antes de reenviarlas a Nimblebit, así que nunca tocas salts ni hashes. Autentícate con una clave de API como token bearer:",
+        howItWorksScopes:
+            "Cada clave lleva scopes, uno por familia de endpoints, y su propio límite de solicitudes. Inicia sesión con tu cuenta de Tinyburg para crear tú mismo claves de solo lectura, ver las claves que tienes y rotar las que se filtren.",
+        sdkHeading: "Usa el SDK",
+        sdkIntroBefore: "Este proxy sirve las mismas definiciones de endpoints a partir de las cuales está construido ",
+        sdkIntroAfter:
+            ", así que un cliente TypeScript tipado sale gratis. Decodifica partidas guardadas, amigos, regalos, visitas y sorteos en tipos reales, y ya sabe apuntarse hacia aquí:",
+        // REVIEW: "Nimblebit soup" is playful in the original; kept the image.
+        sdkOutro:
+            "AUTH_KEY es la clave del proxy que creaste aquí; PLAYER_ID y PLAYER_AUTH_KEY nombran la torre en cuyo nombre actúas. Las partidas descargadas llegan como sopa de Nimblebit comprimida con gzip: pásalas al esquema SaveData del SDK y obtendrás pisos, bitizens, misiones y amigos como valores tipados normales.",
+        testKeysHeading: "Claves de prueba públicas",
+        testKeysIntro: "Existen dos claves compartidas para probar. Tienen límite de solicitudes por dirección IP:",
+        testKeysOutro:
+            "Las claves personales tienen límite por clave y empiezan con 10 solicitudes por minuto. ¿Necesitas scopes de escritura o un límite mayor? Escríbenos en Discord.",
+        footerBefore: "Parte de ",
+        footerAfter: ", sin afiliación con Nimblebit.",
+    },
+    login: {
+        // REVIEW: "Self Service" rendered as "autoservicio"; may read like a shop.
+        heading: "Autoservicio de Authproxy",
+        subheading: "Tu cuenta de Tinyburg es tu identidad aquí: un solo inicio de sesión, sin contraseña nueva.",
+        signInWithTinyburg: "Inicia sesión con Tinyburg",
+        noAccountBefore: "¿Aún no tienes cuenta de Tinyburg? ",
+        createAccountLink: "Crea una en tinyburg.app",
+        noAccountAfter: " primero.",
+        cancelled: "Cancelaste el inicio de sesión. Puedes retomarlo cuando quieras.",
+        interrupted:
+            "Ese intento de inicio de sesión caducó o se interrumpió. Empieza de nuevo y comprueba que tu navegador permite cookies para este sitio.",
+        failed: "No pudimos terminar de iniciar tu sesión. Inténtalo de nuevo.",
+    },
+    keys: {
+        heading: "Tus claves de API",
+        headingFor: (name) => `Claves de API de ${name}`,
+        signOut: "Cerrar sesión",
+        sectionHeading: "Tus claves de API",
+        sectionIntro: "Rota cualquier clave que se te haya podido filtrar y elimina las que ya no uses.",
+        loading: "Cargando tus claves...",
+        loadFailed: "No pudimos cargar tus claves. Inténtalo de nuevo.",
+        emptyState: "Aún no hay claves. Crea una y empieza a llamar al proxy.",
+        newKey: "+ Nueva clave",
+        maxKeysTitle: (maxKeys) => `Cada cuenta puede tener como máximo ${maxKeys} claves`,
+        provisionTitle: "Crear una clave nueva",
+        copy: "Copiar",
+        rotate: "Rotar",
+        rotateTitle: "Emite una clave nueva para esta fila; la antigua deja de funcionar de inmediato",
+        createdLastUsed: (created, lastUsed) => `Creada el ${created} · Último uso el ${lastUsed}`,
+        descriptionLabel: "¿Para qué es esta clave?",
+        descriptionPlaceholder: "Descripción opcional, p. ej. mi bot de estadísticas de torres",
+        readOnlyScopesLabel: "Scopes de solo lectura (elige al menos uno)",
+        writeScopesNote: "Los scopes de escritura se conceden a mano: escríbenos en Discord",
+        createKey: "Crear clave",
+        notices: {
+            copied: "Copiada a tu portapapeles.",
+            created: "Clave creada. Funciona de inmediato.",
+            rotated: "Clave rotada. La antigua dejó de funcionar en el momento en que se emitió la nueva.",
+            revoked: "Clave revocada. Las solicitudes con ella ahora fallan.",
+            reEnabled: "Clave reactivada.",
+            deleted: "Clave eliminada.",
+        },
+        problems: {
+            actionFailed: "Eso no funcionó. Inténtalo de nuevo.",
+            createRefused: (maxKeys) =>
+                `Esa solicitud fue rechazada. Las claves necesitan al menos un scope y cada cuenta puede tener como máximo ${maxKeys} claves.`,
+            clipboardFailed: "No pudimos acceder a tu portapapeles. Inténtalo de nuevo.",
+        },
+    },
+    admin: {
+        heading: "Admin",
+        yourKeysLink: "Tus claves",
+        // REVIEW: "step up" rendered as raising privileges; no snappy Spanish idiom.
+        stepUpHeading: "Elevar permisos",
+        stepUpIntro:
+            "Las acciones de admin necesitan más que una sesión: introduces la contraseña de admin y vuelves a autorizar con Tinyburg para que el proxy pueda comprobar, con tu consentimiento, que tu cuenta tiene una torre en la lista de permitidos. La elevación dura una hora.",
+        passwordPlaceholder: "Contraseña de admin",
+        // REVIEW: mirrors "Elevate with Tinyburg"; reads unusual in Spanish too.
+        elevate: "Elevar con Tinyburg",
+        allKeysHeading: "Todas las claves",
+        allKeysIntro:
+            "Todas las claves que el proxy ha emitido, las tenga quien las tenga. Los scopes de escritura se conceden aquí.",
+        loading: "Cargando...",
+        loadFailed: "No pudimos cargar las claves. Inténtalo de nuevo.",
+        emptyState: "Todavía no existe ninguna clave.",
+        owner: (sub) => `Propietario ${sub}`,
+        noOwner: "Sin propietario (emitida por un admin)",
+        scopesButton: "Scopes",
+        rateLimitButton: "Límite de solicitudes",
+        saveScopes: "Guardar scopes",
+        saveLimit: "Guardar límite",
+        requestsLabel: "Solicitudes",
+        // REVIEW: matches the quirky English "per seconds" next to the window field.
+        perSecondsLabel: "por segundos",
+        notices: {
+            saved: "Guardado.",
+            keyDeleted: "Clave eliminada.",
+        },
+        problems: {
+            elevationFailed:
+                "La elevación fue rechazada. Comprueba la contraseña, que aprobaste la comprobación de la torre y que tu cuenta tiene una torre en la lista de permitidos.",
+            actionFailed: "Eso no funcionó. Inténtalo de nuevo.",
+            rateLimitInvalid: "Los límites de solicitudes necesitan números enteros positivos.",
+        },
+    },
+    notFound: {
+        heading: "404",
+        body: "Este piso todavía no se ha construido.",
+    },
+};

--- a/apps/authproxy/client/messages/fr.ts
+++ b/apps/authproxy/client/messages/fr.ts
@@ -1,0 +1,143 @@
+/**
+ * French messages. Register: informal "tu".
+ *
+ * Kept in English (glossary): Tinyburg, TinyTower, Nimblebit, Authproxy,
+ * bitizen(s), bux, Discord, and technical terms the API surface owns (scope,
+ * jeton bearer, SDK, gzip). "Towers"/"floors"/"friends" translate normally.
+ */
+
+import type { Messages } from "./types.ts";
+
+export const fr: Messages = {
+    titles: {
+        home: "Tinyburg Authproxy | Clés d'API pour les serveurs de Nimblebit",
+        login: "Connexion | Tinyburg Authproxy",
+        keys: "Tes clés d'API | Tinyburg Authproxy",
+        admin: "Admin | Tinyburg Authproxy",
+        notFound: "Page introuvable | Tinyburg Authproxy",
+    },
+    shared: {
+        backToHome: "← Retour à l'accueil",
+        cancel: "Annuler",
+        delete: "Supprimer",
+        rateLimit: (limit, windowSeconds) => `${limit} requêtes / ${windowSeconds}s`,
+        reallyDelete: "Vraiment supprimer ?",
+        reEnable: "Réactiver",
+        revoke: "Révoquer",
+        revokedBadge: "Révoquée",
+    },
+    home: {
+        title: "Tinyburg Authproxy",
+        tagline: "Un accès authentifié et limité en débit aux serveurs TinyTower de Nimblebit.",
+        manageKeys: "Gérer tes clés d'API →",
+        signIn: "Se connecter avec Tinyburg →",
+        howItWorksHeading: "Comment ça marche",
+        howItWorksIntro:
+            "Le proxy signe tes requêtes avant de les transmettre à Nimblebit : tu ne touches jamais aux salts ni aux hashes. Authentifie-toi avec une clé d'API comme jeton bearer :",
+        howItWorksScopes:
+            "Une clé porte des scopes, un par famille d'endpoints, et sa propre limite de débit. Connecte-toi avec ton compte Tinyburg pour créer toi-même des clés en lecture seule, voir les clés que tu détiens et régénérer celles qui fuient.",
+        sdkHeading: "Utiliser le SDK",
+        sdkIntroBefore: "Ce proxy sert les mêmes définitions d'endpoints que celles à partir desquelles ",
+        sdkIntroAfter:
+            " est construit, donc un client TypeScript typé est offert. Il décode les sauvegardes, les amis, les cadeaux, les visites et les tombolas en vrais types, et il sait déjà se diriger ici :",
+        // REVIEW: "Nimblebit soup" is playful in the original; kept the image.
+        sdkOutro:
+            "AUTH_KEY est la clé du proxy que tu as créée ici ; PLAYER_ID et PLAYER_AUTH_KEY désignent la tour au nom de laquelle tu agis. Les sauvegardes récupérées arrivent en soupe Nimblebit compressée en gzip : passe-les au schéma SaveData du SDK et tu obtiens les étages, les bitizens, les missions et les amis comme valeurs typées ordinaires.",
+        testKeysHeading: "Clés de test publiques",
+        testKeysIntro: "Deux clés partagées existent pour essayer. Elles sont limitées en débit par adresse IP :",
+        testKeysOutro:
+            "Les clés personnelles sont limitées en débit par clé et démarrent à 10 requêtes par minute. Besoin de scopes en écriture ou d'une limite plus haute ? Passe nous voir sur Discord.",
+        footerBefore: "Fait partie de ",
+        footerAfter: ", sans affiliation avec Nimblebit.",
+    },
+    login: {
+        // REVIEW: "Self Service" rendered as "libre-service"; may read like a shop.
+        heading: "Authproxy en libre-service",
+        subheading: "Ton compte Tinyburg est ton identité ici : une seule connexion, pas de nouveau mot de passe.",
+        signInWithTinyburg: "Se connecter avec Tinyburg",
+        noAccountBefore: "Pas encore de compte Tinyburg ? ",
+        createAccountLink: "Crées-en d'abord un sur tinyburg.app",
+        noAccountAfter: ".",
+        cancelled: "La connexion a été annulée. Tu peux reprendre où tu en étais quand tu veux.",
+        interrupted:
+            "Cette tentative de connexion a expiré ou a été interrompue. Recommence et vérifie que ton navigateur accepte les cookies pour ce site.",
+        failed: "Nous n'avons pas pu terminer ta connexion. Réessaie.",
+    },
+    keys: {
+        heading: "Tes clés d'API",
+        headingFor: (name) => `Clés d'API de ${name}`,
+        signOut: "Se déconnecter",
+        sectionHeading: "Tes clés d'API",
+        sectionIntro: "Régénère toute clé qui aurait pu fuiter et supprime celles que tu n'utilises plus.",
+        loading: "Chargement de tes clés...",
+        loadFailed: "Nous n'avons pas pu charger tes clés. Réessaie.",
+        emptyState: "Pas encore de clé. Crées-en une et commence à appeler le proxy.",
+        newKey: "+ Nouvelle clé",
+        maxKeysTitle: (maxKeys) => `Chaque compte peut détenir au plus ${maxKeys} clés`,
+        provisionTitle: "Créer une nouvelle clé",
+        copy: "Copier",
+        // REVIEW: "rotate" rendered as "régénérer"; "faire une rotation" felt heavy.
+        rotate: "Régénérer",
+        rotateTitle: "Émet une nouvelle clé pour cette ligne ; l'ancienne cesse de fonctionner immédiatement",
+        createdLastUsed: (created, lastUsed) => `Créée le ${created} · Dernière utilisation le ${lastUsed}`,
+        descriptionLabel: "À quoi sert cette clé ?",
+        descriptionPlaceholder: "Description facultative, p. ex. mon bot de stats de tours",
+        readOnlyScopesLabel: "Scopes en lecture seule (choisis-en au moins un)",
+        writeScopesNote: "Les scopes en écriture sont accordés à la main : passe nous voir sur Discord",
+        createKey: "Créer la clé",
+        notices: {
+            copied: "Copiée dans ton presse-papiers.",
+            created: "Clé créée. Elle fonctionne immédiatement.",
+            rotated: "Clé régénérée. L'ancienne clé a cessé de fonctionner dès que la nouvelle a été émise.",
+            revoked: "Clé révoquée. Les requêtes qui l'utilisent échouent désormais.",
+            reEnabled: "Clé réactivée.",
+            deleted: "Clé supprimée.",
+        },
+        problems: {
+            actionFailed: "Ça n'a pas fonctionné. Réessaie.",
+            createRefused: (maxKeys) =>
+                `Cette requête a été refusée. Une clé a besoin d'au moins un scope, et chaque compte peut détenir au plus ${maxKeys} clés.`,
+            clipboardFailed: "Nous n'avons pas pu accéder à ton presse-papiers. Réessaie.",
+        },
+    },
+    admin: {
+        heading: "Admin",
+        yourKeysLink: "Tes clés",
+        // REVIEW: "step up" rendered as raising privileges; no snappy French idiom.
+        stepUpHeading: "Élever les droits",
+        stepUpIntro:
+            "Les actions d'admin demandent plus qu'une session : tu saisis le mot de passe admin, puis tu réautorises avec Tinyburg pour que le proxy puisse vérifier, avec ton accord, que ton compte détient une tour sur liste autorisée. L'élévation dure une heure.",
+        passwordPlaceholder: "Mot de passe admin",
+        // REVIEW: mirrors "Elevate with Tinyburg"; reads unusual in French too.
+        elevate: "Élever avec Tinyburg",
+        allKeysHeading: "Toutes les clés",
+        allKeysIntro:
+            "Chaque clé émise par le proxy, qui que soit son détenteur. Les scopes en écriture s'accordent ici.",
+        loading: "Chargement...",
+        loadFailed: "Nous n'avons pas pu charger les clés. Réessaie.",
+        emptyState: "Aucune clé n'existe pour l'instant.",
+        owner: (sub) => `Propriétaire ${sub}`,
+        noOwner: "Sans propriétaire (émise par un admin)",
+        scopesButton: "Scopes",
+        rateLimitButton: "Limite de débit",
+        saveScopes: "Enregistrer les scopes",
+        saveLimit: "Enregistrer la limite",
+        requestsLabel: "Requêtes",
+        // REVIEW: matches the quirky English "per seconds" next to the window field.
+        perSecondsLabel: "par secondes",
+        notices: {
+            saved: "Enregistré.",
+            keyDeleted: "Clé supprimée.",
+        },
+        problems: {
+            elevationFailed:
+                "L'élévation a été refusée. Vérifie le mot de passe, que tu as bien approuvé la vérification de la tour et que ton compte détient une tour sur liste autorisée.",
+            actionFailed: "Ça n'a pas fonctionné. Réessaie.",
+            rateLimitInvalid: "Les limites de débit demandent des nombres entiers positifs.",
+        },
+    },
+    notFound: {
+        heading: "404",
+        body: "Cet étage n'a pas encore été construit.",
+    },
+};

--- a/apps/authproxy/client/messages/index.ts
+++ b/apps/authproxy/client/messages/index.ts
@@ -1,0 +1,12 @@
+import type { Language } from "@tinyburg/ui/Internationalization";
+import type { Messages } from "./types.ts";
+
+import { de } from "./de.ts";
+import { en } from "./en.ts";
+import { es } from "./es.ts";
+import { fr } from "./fr.ts";
+
+const byLanguage: Record<Language, Messages> = { de, en, es, fr };
+
+/** The full message catalog for a language; reference-stable per language. */
+export const messagesFor = (language: Language): Messages => byLanguage[language];

--- a/apps/authproxy/client/messages/index.ts
+++ b/apps/authproxy/client/messages/index.ts
@@ -1,5 +1,5 @@
-import type { Language } from "@tinyburg/ui/Internationalization";
 import type { Messages } from "./types.ts";
+import type { Language } from "@tinyburg/ui/Internationalization";
 
 import { de } from "./de.ts";
 import { en } from "./en.ts";

--- a/apps/authproxy/client/messages/types.ts
+++ b/apps/authproxy/client/messages/types.ts
@@ -1,0 +1,150 @@
+/**
+ * One interface per page file, mirroring `pages/*.ts`, plus the document
+ * titles and the chrome copy shared by more than one page. Interpolated
+ * strings are functions, so word order stays the translator's call.
+ *
+ * The scope catalog in `shared/scopes.ts` (labels and descriptions of the
+ * proxy's endpoint families) is part of the API surface and stays English,
+ * like the endpoint paths it names.
+ */
+
+/** Document titles, one per route. */
+export interface TitleMessages {
+    readonly home: string;
+    readonly login: string;
+    readonly keys: string;
+    readonly admin: string;
+    readonly notFound: string;
+}
+
+/** Chrome copy used by more than one page. */
+export interface SharedMessages {
+    readonly backToHome: string;
+    readonly cancel: string;
+    readonly delete: string;
+    readonly rateLimit: (limit: number, windowSeconds: number) => string;
+    readonly reallyDelete: string;
+    readonly reEnable: string;
+    readonly revoke: string;
+    readonly revokedBadge: string;
+}
+
+export interface HomeMessages {
+    readonly title: string;
+    readonly tagline: string;
+    readonly manageKeys: string;
+    readonly signIn: string;
+    readonly howItWorksHeading: string;
+    readonly howItWorksIntro: string;
+    readonly howItWorksScopes: string;
+    readonly sdkHeading: string;
+    /** Wraps the `@tinyburg/tinytower-sdk` link, so it splits around it. */
+    readonly sdkIntroBefore: string;
+    readonly sdkIntroAfter: string;
+    readonly sdkOutro: string;
+    readonly testKeysHeading: string;
+    readonly testKeysIntro: string;
+    readonly testKeysOutro: string;
+    /** Wraps the tinyburg.app link, so it splits around it. */
+    readonly footerBefore: string;
+    readonly footerAfter: string;
+}
+
+export interface LoginMessages {
+    readonly heading: string;
+    readonly subheading: string;
+    readonly signInWithTinyburg: string;
+    /** Wraps the tinyburg.app/login link, so it splits around it. */
+    readonly noAccountBefore: string;
+    readonly createAccountLink: string;
+    readonly noAccountAfter: string;
+    readonly cancelled: string;
+    readonly interrupted: string;
+    readonly failed: string;
+}
+
+export interface KeysMessages {
+    readonly heading: string;
+    readonly headingFor: (name: string) => string;
+    readonly signOut: string;
+    readonly sectionHeading: string;
+    readonly sectionIntro: string;
+    readonly loading: string;
+    readonly loadFailed: string;
+    readonly emptyState: string;
+    readonly newKey: string;
+    readonly maxKeysTitle: (maxKeys: number) => string;
+    readonly provisionTitle: string;
+    readonly copy: string;
+    readonly rotate: string;
+    readonly rotateTitle: string;
+    readonly createdLastUsed: (created: string, lastUsed: string) => string;
+    readonly descriptionLabel: string;
+    readonly descriptionPlaceholder: string;
+    readonly readOnlyScopesLabel: string;
+    readonly writeScopesNote: string;
+    readonly createKey: string;
+    /** Keyed by the notice tags the keys page stores in its model. */
+    readonly notices: {
+        readonly copied: string;
+        readonly created: string;
+        readonly rotated: string;
+        readonly revoked: string;
+        readonly reEnabled: string;
+        readonly deleted: string;
+    };
+    /** Keyed by the problem tags the keys page stores in its model. */
+    readonly problems: {
+        readonly actionFailed: string;
+        readonly createRefused: (maxKeys: number) => string;
+        readonly clipboardFailed: string;
+    };
+}
+
+export interface AdminMessages {
+    readonly heading: string;
+    readonly yourKeysLink: string;
+    readonly stepUpHeading: string;
+    readonly stepUpIntro: string;
+    readonly passwordPlaceholder: string;
+    readonly elevate: string;
+    readonly allKeysHeading: string;
+    readonly allKeysIntro: string;
+    readonly loading: string;
+    readonly loadFailed: string;
+    readonly emptyState: string;
+    readonly owner: (sub: string) => string;
+    readonly noOwner: string;
+    readonly scopesButton: string;
+    readonly rateLimitButton: string;
+    readonly saveScopes: string;
+    readonly saveLimit: string;
+    readonly requestsLabel: string;
+    readonly perSecondsLabel: string;
+    /** Keyed by the notice tags the admin page stores in its model. */
+    readonly notices: {
+        readonly saved: string;
+        readonly keyDeleted: string;
+    };
+    /** Keyed by the problem tags the admin page stores in its model. */
+    readonly problems: {
+        readonly elevationFailed: string;
+        readonly actionFailed: string;
+        readonly rateLimitInvalid: string;
+    };
+}
+
+export interface NotFoundMessages {
+    readonly heading: string;
+    readonly body: string;
+}
+
+export interface Messages {
+    readonly titles: TitleMessages;
+    readonly shared: SharedMessages;
+    readonly home: HomeMessages;
+    readonly login: LoginMessages;
+    readonly keys: KeysMessages;
+    readonly admin: AdminMessages;
+    readonly notFound: NotFoundMessages;
+}

--- a/apps/authproxy/client/pages/admin.ts
+++ b/apps/authproxy/client/pages/admin.ts
@@ -1,6 +1,7 @@
 import { Duration, Effect, Match, Option, Result, Schema as S } from "effect";
 
 import type { Message as AppMessage } from "../main.ts";
+import type { AdminMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { banner, card, dangerButton, primaryButton, quietButton, smallButton } from "@tinyburg/ui/Chrome";
@@ -16,7 +17,13 @@ type Key = typeof Account.json.Type;
 
 // MODEL
 
-export const AdminKeys = AsyncData.Schema(S.Array(Account.json), S.String);
+// The model holds language-independent tags for what happened; the view
+// supplies the words from the message catalog.
+const AdminNotice = S.Literals(["saved", "keyDeleted"]);
+const AdminProblem = S.Literals(["elevationFailed", "actionFailed", "rateLimitInvalid"]);
+const LoadFailed = S.Literals(["loadFailed"]);
+
+export const AdminKeys = AsyncData.Schema(S.Array(Account.json), LoadFailed);
 
 const ScopesEditor = S.Struct({ key: S.String, scopes: S.Array(S.String) });
 const RateLimitEditor = S.Struct({ key: S.String, limit: S.String, windowSeconds: S.String });
@@ -28,8 +35,8 @@ export const AdminModel = S.Struct({
     needsElevation: S.Boolean,
 
     busy: S.Option(S.String),
-    notice: S.Option(S.String),
-    problem: S.Option(S.String),
+    notice: S.Option(AdminNotice),
+    problem: S.Option(AdminProblem),
     armedDelete: S.Option(S.String),
 
     // At most one row is being edited at a time.
@@ -49,9 +56,6 @@ export const initialAdmin: AdminModel = {
     rateLimitEditor: Option.none(),
 };
 
-const ELEVATION_FAILED =
-    "Elevation was refused. Check the password, that you approved the tower check, and that your account holds an allowlisted tower.";
-
 /**
  * The admin page as entered: held data stays, transient state clears. The
  * elevation round trip lands back here with its outcome in the url, so the
@@ -61,7 +65,7 @@ export const enterAdmin = (error: Option.Option<string>, previous: AdminModel): 
     evo(previous, {
         busy: Option.none,
         notice: Option.none,
-        problem: () => Option.map(error, () => ELEVATION_FAILED),
+        problem: () => Option.map(error, () => "elevationFailed" as const),
         armedDelete: Option.none,
         scopesEditor: Option.none,
         rateLimitEditor: Option.none,
@@ -69,7 +73,7 @@ export const enterAdmin = (error: Option.Option<string>, previous: AdminModel): 
 
 // MESSAGE
 
-export const SettledAdminKeys = m("SettledAdminKeys", { result: S.Result(S.Array(Account.json), S.String) });
+export const SettledAdminKeys = m("SettledAdminKeys", { result: S.Result(S.Array(Account.json), LoadFailed) });
 
 /** The admin surface refused a plain session; show the step-up form. */
 export const AdminRequiresElevation = m("AdminRequiresElevation");
@@ -86,7 +90,7 @@ export const ClickedAdminSetRevoked = m("ClickedAdminSetRevoked", { key: S.Strin
 export const ClickedAdminDelete = m("ClickedAdminDelete", { key: S.String });
 export const CompletedAdminRowUpdate = m("CompletedAdminRowUpdate");
 export const CompletedAdminDelete = m("CompletedAdminDelete");
-export const FailedAdminAction = m("FailedAdminAction", { message: S.String });
+export const FailedAdminAction = m("FailedAdminAction", { problem: AdminProblem });
 
 /** The session ended somewhere else while this page was open. */
 export const AdminSignedOutElsewhere = m("AdminSignedOutElsewhere");
@@ -112,9 +116,6 @@ export type AdminMessage = typeof AdminMessage.Type;
 
 // COMMAND
 
-const LOAD_FAILED = "We couldn't load the keys. Please try again.";
-const ACTION_FAILED = "That didn't work. Please try again.";
-
 export const FetchAdminKeys = Command.define("FetchAdminKeys", {
     messages: [SettledAdminKeys, AdminRequiresElevation, AdminSignedOutElsewhere],
     execute: Effect.gen(function* () {
@@ -124,7 +125,7 @@ export const FetchAdminKeys = Command.define("FetchAdminKeys", {
     }).pipe(
         Effect.catchTag("Unauthorized", () => Effect.succeed(AdminSignedOutElsewhere())),
         Effect.catchTag("Forbidden", () => Effect.succeed(AdminRequiresElevation())),
-        Effect.catch(() => Effect.succeed(SettledAdminKeys({ result: Result.fail(LOAD_FAILED) })))
+        Effect.catch(() => Effect.succeed(SettledAdminKeys({ result: Result.fail("loadFailed" as const) })))
     ),
 });
 
@@ -139,7 +140,7 @@ const SaveScopes = Command.define("SaveScopes", {
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(AdminSignedOutElsewhere())),
             Effect.catchTag("Forbidden", () => Effect.succeed(AdminRequiresElevation())),
-            Effect.catch(() => Effect.succeed(FailedAdminAction({ message: ACTION_FAILED })))
+            Effect.catch(() => Effect.succeed(FailedAdminAction({ problem: "actionFailed" })))
         ),
 });
 
@@ -157,7 +158,7 @@ const SaveRateLimit = Command.define("SaveRateLimit", {
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(AdminSignedOutElsewhere())),
             Effect.catchTag("Forbidden", () => Effect.succeed(AdminRequiresElevation())),
-            Effect.catch(() => Effect.succeed(FailedAdminAction({ message: ACTION_FAILED })))
+            Effect.catch(() => Effect.succeed(FailedAdminAction({ problem: "actionFailed" })))
         ),
 });
 
@@ -172,7 +173,7 @@ const SetRevokedAdmin = Command.define("SetRevokedAdmin", {
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(AdminSignedOutElsewhere())),
             Effect.catchTag("Forbidden", () => Effect.succeed(AdminRequiresElevation())),
-            Effect.catch(() => Effect.succeed(FailedAdminAction({ message: ACTION_FAILED })))
+            Effect.catch(() => Effect.succeed(FailedAdminAction({ problem: "actionFailed" })))
         ),
 });
 
@@ -187,7 +188,7 @@ const DeleteKeyAdmin = Command.define("DeleteKeyAdmin", {
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(AdminSignedOutElsewhere())),
             Effect.catchTag("Forbidden", () => Effect.succeed(AdminRequiresElevation())),
-            Effect.catch(() => Effect.succeed(FailedAdminAction({ message: ACTION_FAILED })))
+            Effect.catch(() => Effect.succeed(FailedAdminAction({ problem: "actionFailed" })))
         ),
 });
 
@@ -287,7 +288,7 @@ export const updateAdmin = (model: AdminModel, message: AdminMessage): AdminStep
                     ) {
                         return [
                             evo(model, {
-                                problem: () => Option.some("Rate limits need positive whole numbers."),
+                                problem: () => Option.some("rateLimitInvalid" as const),
                             }),
                             [],
                         ];
@@ -310,19 +311,19 @@ export const updateAdmin = (model: AdminModel, message: AdminMessage): AdminStep
             CompletedAdminRowUpdate: () => [
                 evo(refetching(model), {
                     busy: Option.none,
-                    notice: () => Option.some("Saved."),
+                    notice: () => Option.some("saved" as const),
                     scopesEditor: Option.none,
                     rateLimitEditor: Option.none,
                 }),
                 [FetchAdminKeys()],
             ],
             CompletedAdminDelete: () => [
-                evo(refetching(model), { busy: Option.none, notice: () => Option.some("Key deleted.") }),
+                evo(refetching(model), { busy: Option.none, notice: () => Option.some("keyDeleted" as const) }),
                 [FetchAdminKeys()],
             ],
 
-            FailedAdminAction: ({ message }) => [
-                evo(model, { busy: Option.none, problem: () => Option.some(message) }),
+            FailedAdminAction: ({ problem }) => [
+                evo(model, { busy: Option.none, problem: () => Option.some(problem) }),
                 [],
             ],
             AdminSignedOutElsewhere: () => [evo(model, { busy: Option.none }), []],
@@ -345,17 +346,12 @@ const scopeChip = (h: HtmlBuilder<AppMessage>, path: string): Html =>
  * password to the server, which sends the browser through tinyburg.app to
  * re-authorize with `towers:read`, and the outcome lands back on /admin.
  */
-const elevationForm = <M>(h: HtmlBuilder<M>): Html =>
+const elevationForm = <M>(h: HtmlBuilder<M>, msgs: AdminMessages): Html =>
     h.section(
         [h.Class(card + " max-w-md")],
         [
-            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], ["Step Up"]),
-            h.p(
-                [h.Class("font-mono mb-6 text-lg text-gray-500")],
-                [
-                    "Admin actions need more than a session: you enter the admin password, then re-authorize with Tinyburg so the proxy can check - with your consent - that your account holds an allowlisted tower. Elevation lasts an hour.",
-                ]
-            ),
+            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], [msgs.stepUpHeading]),
+            h.p([h.Class("font-mono mb-6 text-lg text-gray-500")], [msgs.stepUpIntro]),
             h.form(
                 [h.Method("post"), h.Action("/auth/elevate"), h.Class("flex flex-col gap-4")],
                 [
@@ -367,15 +363,21 @@ const elevationForm = <M>(h: HtmlBuilder<M>): Html =>
                         h.Class(
                             "font-mono focus:border-sky-blue rounded-lg border-2 border-gray-300 bg-white px-3 py-2 text-xl outline-none"
                         ),
-                        h.Placeholder("Admin password"),
+                        h.Placeholder(msgs.passwordPlaceholder),
                     ]),
-                    h.button([h.Type("submit"), h.Class(primaryButton)], ["Elevate with Tinyburg"]),
+                    h.button([h.Type("submit"), h.Class(primaryButton)], [msgs.elevate]),
                 ]
             ),
         ]
     );
 
-const scopesEditorView = (h: HtmlBuilder<AppMessage>, model: AdminModel, selected: ReadonlyArray<string>): Html =>
+const scopesEditorView = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: AdminMessages,
+    shared: SharedMessages,
+    model: AdminModel,
+    selected: ReadonlyArray<string>
+): Html =>
     h.div(
         [h.Class("flex flex-col gap-3 rounded-lg border-2 border-gray-200 bg-gray-50 p-3")],
         [
@@ -405,9 +407,12 @@ const scopesEditorView = (h: HtmlBuilder<AppMessage>, model: AdminModel, selecte
                             h.Disabled(selected.length === 0 || Option.isSome(model.busy)),
                             h.OnClick(SubmittedAdminEdit()),
                         ],
-                        ["Save scopes"]
+                        [msgs.saveScopes]
                     ),
-                    h.button([h.Type("button"), h.Class(quietButton), h.OnClick(ClickedCancelAdminEdit())], ["Cancel"]),
+                    h.button(
+                        [h.Type("button"), h.Class(quietButton), h.OnClick(ClickedCancelAdminEdit())],
+                        [shared.cancel]
+                    ),
                 ]
             ),
         ]
@@ -415,6 +420,8 @@ const scopesEditorView = (h: HtmlBuilder<AppMessage>, model: AdminModel, selecte
 
 const rateLimitEditorView = (
     h: HtmlBuilder<AppMessage>,
+    msgs: AdminMessages,
+    shared: SharedMessages,
     model: AdminModel,
     editor: { readonly limit: string; readonly windowSeconds: string }
 ): Html => {
@@ -438,8 +445,8 @@ const rateLimitEditorView = (
     return h.div(
         [h.Class("flex flex-wrap items-center gap-3 rounded-lg border-2 border-gray-200 bg-gray-50 p-3")],
         [
-            field("Requests", editor.limit, (value) => ChangedAdminLimit({ value })),
-            field("per seconds", editor.windowSeconds, (value) => ChangedAdminWindow({ value })),
+            field(msgs.requestsLabel, editor.limit, (value) => ChangedAdminLimit({ value })),
+            field(msgs.perSecondsLabel, editor.windowSeconds, (value) => ChangedAdminWindow({ value })),
             h.button(
                 [
                     h.Type("button"),
@@ -447,14 +454,20 @@ const rateLimitEditorView = (
                     h.Disabled(Option.isSome(model.busy)),
                     h.OnClick(SubmittedAdminEdit()),
                 ],
-                ["Save limit"]
+                [msgs.saveLimit]
             ),
-            h.button([h.Type("button"), h.Class(quietButton), h.OnClick(ClickedCancelAdminEdit())], ["Cancel"]),
+            h.button([h.Type("button"), h.Class(quietButton), h.OnClick(ClickedCancelAdminEdit())], [shared.cancel]),
         ]
     );
 };
 
-const adminKeyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: AdminModel): Html => {
+const adminKeyRow = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: AdminMessages,
+    shared: SharedMessages,
+    key: Key,
+    model: AdminModel
+): Html => {
     const busy = Option.contains(model.busy, key.key);
     const armed = Option.contains(model.armedDelete, key.key);
     const editingScopes = model.scopesEditor.pipe(
@@ -480,7 +493,7 @@ const adminKeyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: AdminModel): H
                     key.revoked
                         ? h.span(
                               [h.Class("font-pixel rounded bg-red-700 px-2 py-1 text-[0.5rem] text-white")],
-                              ["Revoked"]
+                              [shared.revokedBadge]
                           )
                         : h.empty,
                 ]
@@ -489,14 +502,14 @@ const adminKeyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: AdminModel): H
                 [h.Class("font-mono text-base text-gray-500")],
                 [
                     Option.match(key.ownerSub, {
-                        onSome: (sub) => `Owner ${sub}`,
-                        onNone: () => "No owner (admin-issued)",
+                        onSome: (sub) => msgs.owner(sub),
+                        onNone: () => msgs.noOwner,
                     }),
                     ...Option.match(key.description, {
                         onSome: (description) => [` · ${description}`],
                         onNone: () => [],
                     }),
-                    ` · ${key.rateLimitLimit} requests / ${Math.round(Duration.toSeconds(key.rateLimitWindow))}s`,
+                    ` · ${shared.rateLimit(key.rateLimitLimit, Math.round(Duration.toSeconds(key.rateLimitWindow)))}`,
                 ]
             ),
             h.div(
@@ -504,11 +517,11 @@ const adminKeyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: AdminModel): H
                 Array.from(key.scopes, (scope) => scopeChip(h, scope))
             ),
             ...Option.match(editingScopes, {
-                onSome: (selected) => [scopesEditorView(h, model, selected)],
+                onSome: (selected) => [scopesEditorView(h, msgs, shared, model, selected)],
                 onNone: () => [],
             }),
             ...Option.match(editingRateLimit, {
-                onSome: (editor) => [rateLimitEditorView(h, model, editor)],
+                onSome: (editor) => [rateLimitEditorView(h, msgs, shared, model, editor)],
                 onNone: () => [],
             }),
             h.div(
@@ -521,7 +534,7 @@ const adminKeyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: AdminModel): H
                             h.Disabled(busy),
                             h.OnClick(ClickedEditScopes({ key: key.key })),
                         ],
-                        ["Scopes"]
+                        [msgs.scopesButton]
                     ),
                     h.button(
                         [
@@ -530,7 +543,7 @@ const adminKeyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: AdminModel): H
                             h.Disabled(busy),
                             h.OnClick(ClickedEditRateLimit({ key: key.key })),
                         ],
-                        ["Rate limit"]
+                        [msgs.rateLimitButton]
                     ),
                     h.button(
                         [
@@ -539,7 +552,7 @@ const adminKeyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: AdminModel): H
                             h.Disabled(busy),
                             h.OnClick(ClickedAdminSetRevoked({ key: key.key, revoked: !key.revoked })),
                         ],
-                        [busy ? "..." : key.revoked ? "Re-enable" : "Revoke"]
+                        [busy ? "..." : key.revoked ? shared.reEnable : shared.revoke]
                     ),
                     h.button(
                         [
@@ -548,7 +561,7 @@ const adminKeyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: AdminModel): H
                             h.Disabled(busy),
                             h.OnClick(ClickedAdminDelete({ key: key.key })),
                         ],
-                        [busy ? "..." : armed ? "Really delete?" : "Delete"]
+                        [busy ? "..." : armed ? shared.reallyDelete : shared.delete]
                     ),
                 ]
             ),
@@ -556,27 +569,29 @@ const adminKeyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: AdminModel): H
     );
 };
 
-const keysTable = (h: HtmlBuilder<AppMessage>, model: AdminModel): Html => {
+const keysTable = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: AdminMessages,
+    shared: SharedMessages,
+    model: AdminModel
+): Html => {
     const list = (keys: ReadonlyArray<Key>): Html =>
         h.div(
             [h.Class("flex flex-col gap-4")],
             keys.length === 0
-                ? [h.p([h.Class("font-mono text-xl text-gray-600")], ["No keys exist yet."])]
-                : keys.map((key) => adminKeyRow(h, key, model))
+                ? [h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.emptyState])]
+                : keys.map((key) => adminKeyRow(h, msgs, shared, key, model))
         );
 
     return h.section(
         [h.Class(card)],
         [
-            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], ["All Keys"]),
-            h.p(
-                [h.Class("font-mono mb-6 text-lg text-gray-500")],
-                ["Every key the proxy has issued, whoever holds it. Write scopes are granted here."]
-            ),
+            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], [msgs.allKeysHeading]),
+            h.p([h.Class("font-mono mb-6 text-lg text-gray-500")], [msgs.allKeysIntro]),
             AsyncData.match(model.keys, {
-                onIdle: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading..."]),
-                onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading..."]),
-                onFailure: (error) => h.p([h.Class("font-mono text-xl text-red-700")], [error]),
+                onIdle: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loading]),
+                onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loading]),
+                onFailure: () => h.p([h.Class("font-mono text-xl text-red-700")], [msgs.loadFailed]),
                 onRefreshing: list,
                 onStale: ({ data }) => list(data),
                 onSuccess: list,
@@ -585,7 +600,12 @@ const keysTable = (h: HtmlBuilder<AppMessage>, model: AdminModel): Html => {
     );
 };
 
-export const adminView = (h: HtmlBuilder<AppMessage>, model: AdminModel): Html =>
+export const adminView = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: AdminMessages,
+    shared: SharedMessages,
+    model: AdminModel
+): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center p-8 pt-24")],
         [
@@ -595,19 +615,19 @@ export const adminView = (h: HtmlBuilder<AppMessage>, model: AdminModel): Html =
                     h.div(
                         [h.Class("flex flex-wrap items-center justify-between gap-3")],
                         [
-                            h.h1([h.Class("font-pixel text-dark-blue text-lg")], ["Admin"]),
-                            h.a([h.Href("/keys"), h.Class(quietButton + " no-underline")], ["Your keys"]),
+                            h.h1([h.Class("font-pixel text-dark-blue text-lg")], [msgs.heading]),
+                            h.a([h.Href("/keys"), h.Class(quietButton + " no-underline")], [msgs.yourKeysLink]),
                         ]
                     ),
                     ...Option.match(model.notice, {
-                        onSome: (text) => [banner(h, "notice", text)],
+                        onSome: (notice) => [banner(h, "notice", msgs.notices[notice])],
                         onNone: () => [],
                     }),
                     ...Option.match(model.problem, {
-                        onSome: (text) => [banner(h, "problem", text)],
+                        onSome: (problem) => [banner(h, "problem", msgs.problems[problem])],
                         onNone: () => [],
                     }),
-                    model.needsElevation ? elevationForm(h) : keysTable(h, model),
+                    model.needsElevation ? elevationForm(h, msgs) : keysTable(h, msgs, shared, model),
                 ]
             ),
         ]

--- a/apps/authproxy/client/pages/home.ts
+++ b/apps/authproxy/client/pages/home.ts
@@ -1,6 +1,7 @@
 import { Option } from "effect";
 
 import type { SessionState } from "../backend.ts";
+import type { HomeMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { card, primaryButton } from "@tinyburg/ui/Chrome";
@@ -15,7 +16,7 @@ const sectionHeading = <M>(h: HtmlBuilder<M>, text: string): Html =>
  * The front page carries everything an unauthenticated visitor can use: what
  * the proxy is, the public test keys, and the way in.
  */
-export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
+export const homeView = <M>(h: HtmlBuilder<M>, msgs: HomeMessages, session: SessionState): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center gap-6 p-8 pt-16")],
         [
@@ -25,61 +26,45 @@ export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
                     h.div(
                         [h.Class("text-center")],
                         [
-                            h.h1([h.Class("font-pixel text-dark-blue mb-3 text-xl")], ["Tinyburg Authproxy"]),
-                            h.p(
-                                [h.Class("font-mono text-2xl text-white/90")],
-                                ["Authenticated, rate-limited access to Nimblebit's TinyTower servers."]
-                            ),
+                            h.h1([h.Class("font-pixel text-dark-blue mb-3 text-xl")], [msgs.title]),
+                            h.p([h.Class("font-mono text-2xl text-white/90")], [msgs.tagline]),
                         ]
                     ),
                     h.div(
                         [h.Class("flex justify-center")],
                         [
                             session._tag === "SignedIn"
-                                ? h.a(
-                                      [h.Href("/keys"), h.Class(primaryButton + " no-underline")],
-                                      ["Manage your API keys →"]
-                                  )
+                                ? h.a([h.Href("/keys"), h.Class(primaryButton + " no-underline")], [msgs.manageKeys])
                                 : h.a(
                                       [
                                           h.Href(loginHref(Option.some("/keys"))),
                                           h.Class(primaryButton + " no-underline"),
                                       ],
-                                      ["Sign in with Tinyburg →"]
+                                      [msgs.signIn]
                                   ),
                         ]
                     ),
                     h.section(
                         [h.Class(card)],
                         [
-                            sectionHeading(h, "How it works"),
-                            h.p(
-                                [h.Class("font-mono mb-4 text-xl text-gray-700")],
-                                [
-                                    "The proxy signs your requests before forwarding them to Nimblebit, so you never touch salts or hashes. Authenticate with an API key as a bearer token:",
-                                ]
-                            ),
+                            sectionHeading(h, msgs.howItWorksHeading),
+                            h.p([h.Class("font-mono mb-4 text-xl text-gray-700")], [msgs.howItWorksIntro]),
                             codeBlock(
                                 h,
                                 "sh",
                                 `curl -H "Authorization: Bearer <your-key>" \\\n     https://authproxy.tinyburg.app/player_details/tt/:playerId`
                             ),
-                            h.p(
-                                [h.Class("font-mono mt-4 text-xl text-gray-700")],
-                                [
-                                    "A key carries scopes, one per endpoint family, and its own rate limit. Sign in with your Tinyburg account to provision read-only keys yourself, see the keys you hold, and rotate any that leak.",
-                                ]
-                            ),
+                            h.p([h.Class("font-mono mt-4 text-xl text-gray-700")], [msgs.howItWorksScopes]),
                         ]
                     ),
                     h.section(
                         [h.Class(card)],
                         [
-                            sectionHeading(h, "Use the SDK"),
+                            sectionHeading(h, msgs.sdkHeading),
                             h.p(
                                 [h.Class("font-mono mb-4 text-xl text-gray-700")],
                                 [
-                                    "This proxy serves the same endpoint definitions that ",
+                                    msgs.sdkIntroBefore,
                                     h.a(
                                         [
                                             h.Href("https://www.npmjs.com/package/@tinyburg/tinytower-sdk"),
@@ -87,7 +72,7 @@ export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
                                         ],
                                         ["@tinyburg/tinytower-sdk"]
                                     ),
-                                    " is built from, so a typed TypeScript client comes for free. It decodes save data, friends, gifts, visits and raffles into real types, and it already knows how to aim itself here:",
+                                    msgs.sdkIntroAfter,
                                 ]
                             ),
                             h.div(
@@ -126,22 +111,14 @@ export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
                                     ),
                                 ]
                             ),
-                            h.p(
-                                [h.Class("font-mono mt-4 text-xl text-gray-700")],
-                                [
-                                    "AUTH_KEY is the proxy key you provisioned here; PLAYER_ID and PLAYER_AUTH_KEY name the tower you are acting as. Pulled saves come back as gzipped Nimblebit soup — hand them to the SDK's SaveData schema and you get floors, bitizens, missions and friends as ordinary typed values.",
-                                ]
-                            ),
+                            h.p([h.Class("font-mono mt-4 text-xl text-gray-700")], [msgs.sdkOutro]),
                         ]
                     ),
                     h.section(
                         [h.Class(card)],
                         [
-                            sectionHeading(h, "Public test keys"),
-                            h.p(
-                                [h.Class("font-mono mb-4 text-xl text-gray-700")],
-                                ["Two shared keys exist for kicking the tires. They are rate limited by IP address:"]
-                            ),
+                            sectionHeading(h, msgs.testKeysHeading),
+                            h.p([h.Class("font-mono mb-4 text-xl text-gray-700")], [msgs.testKeysIntro]),
                             h.div(
                                 [h.Class("flex flex-col gap-2")],
                                 [
@@ -149,20 +126,15 @@ export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
                                     codeBlock(h, "sh", "00000000-0000-0000-0000-000000000002   # all read-only scopes"),
                                 ]
                             ),
-                            h.p(
-                                [h.Class("font-mono mt-4 text-xl text-gray-700")],
-                                [
-                                    "Personal keys are rate limited per key instead, and start at 10 requests a minute. Need write scopes or a higher limit? Reach out on Discord.",
-                                ]
-                            ),
+                            h.p([h.Class("font-mono mt-4 text-xl text-gray-700")], [msgs.testKeysOutro]),
                         ]
                     ),
                     h.p(
                         [h.Class("text-center font-mono text-lg text-white/80")],
                         [
-                            "Part of ",
+                            msgs.footerBefore,
                             h.a([h.Href("https://tinyburg.app"), h.Class("text-white underline")], ["tinyburg.app"]),
-                            " — not affiliated with Nimblebit.",
+                            msgs.footerAfter,
                         ]
                     ),
                 ]

--- a/apps/authproxy/client/pages/keys.ts
+++ b/apps/authproxy/client/pages/keys.ts
@@ -4,8 +4,8 @@ import type { Message as AppMessage } from "../main.ts";
 import type { KeysMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
-import { type Language, longDate } from "@tinyburg/ui/Internationalization";
 import { banner, card, dangerButton, primaryButton, quietButton, smallButton } from "@tinyburg/ui/Chrome";
+import { type Language, longDate } from "@tinyburg/ui/Internationalization";
 import { AsyncData, Command } from "foldkit";
 import { m } from "foldkit/message";
 import { evo } from "foldkit/struct";

--- a/apps/authproxy/client/pages/keys.ts
+++ b/apps/authproxy/client/pages/keys.ts
@@ -1,8 +1,10 @@
-import { DateTime, Duration, Effect, Match, Option, Result, Schema as S } from "effect";
+import { Duration, Effect, Match, Option, Result, Schema as S } from "effect";
 
 import type { Message as AppMessage } from "../main.ts";
+import type { KeysMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
+import { type Language, longDate } from "@tinyburg/ui/Internationalization";
 import { banner, card, dangerButton, primaryButton, quietButton, smallButton } from "@tinyburg/ui/Chrome";
 import { AsyncData, Command } from "foldkit";
 import { m } from "foldkit/message";
@@ -21,7 +23,15 @@ type Key = typeof Account.json.Type;
 
 // MODEL
 
-export const Keys = AsyncData.Schema(S.Array(Account.json), S.String);
+// The model holds language-independent tags for what happened; the view
+// supplies the words from the message catalog.
+const KeysNotice = S.Literals(["copied", "created", "rotated", "revoked", "reEnabled", "deleted"]);
+type KeysNotice = typeof KeysNotice.Type;
+const KeysProblem = S.Literals(["actionFailed", "createRefused", "clipboardFailed"]);
+type KeysProblem = typeof KeysProblem.Type;
+const LoadFailed = S.Literals(["loadFailed"]);
+
+export const Keys = AsyncData.Schema(S.Array(Account.json), LoadFailed);
 
 export const KeysModel = S.Struct({
     keys: Keys.schema,
@@ -29,8 +39,8 @@ export const KeysModel = S.Struct({
     // The row currently mid-request, so only its own button says so. The
     // create form uses the sentinel "create".
     busy: S.Option(S.String),
-    notice: S.Option(S.String),
-    problem: S.Option(S.String),
+    notice: S.Option(KeysNotice),
+    problem: S.Option(KeysProblem),
 
     // Keys minted in this sitting. A key is shown in full the once, right
     // after it is created or rotated; every later look at it is masked.
@@ -75,7 +85,7 @@ export const enterKeys = (previous: KeysModel): KeysModel =>
 
 // MESSAGE
 
-export const SettledKeys = m("SettledKeys", { result: S.Result(S.Array(Account.json), S.String) });
+export const SettledKeys = m("SettledKeys", { result: S.Result(S.Array(Account.json), LoadFailed) });
 
 export const ClickedOpenCreate = m("ClickedOpenCreate");
 export const ClickedCancelCreate = m("ClickedCancelCreate");
@@ -96,7 +106,7 @@ export const CompletedDelete = m("CompletedDelete");
 export const ClickedCopy = m("ClickedCopy", { key: S.String });
 export const CopiedKey = m("CopiedKey");
 
-export const FailedAction = m("FailedAction", { message: S.String });
+export const FailedAction = m("FailedAction", { problem: KeysProblem });
 
 /** The session ended somewhere else while this page was open. */
 export const SignedOutElsewhere = m("SignedOutElsewhere");
@@ -124,9 +134,6 @@ export type KeysMessage = typeof KeysMessage.Type;
 
 // COMMAND
 
-const LOAD_FAILED = "We couldn't load your keys. Please try again.";
-const ACTION_FAILED = "That didn't work. Please try again.";
-
 export const FetchKeys = Command.define("FetchKeys", {
     messages: [SettledKeys, SignedOutElsewhere],
     execute: Effect.gen(function* () {
@@ -135,7 +142,7 @@ export const FetchKeys = Command.define("FetchKeys", {
         return SettledKeys({ result: Result.succeed(keys) });
     }).pipe(
         Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-        Effect.catch(() => Effect.succeed(SettledKeys({ result: Result.fail(LOAD_FAILED) })))
+        Effect.catch(() => Effect.succeed(SettledKeys({ result: Result.fail("loadFailed" as const) })))
     ),
 });
 
@@ -155,14 +162,8 @@ const CreateKey = Command.define("CreateKey", {
             return CompletedCreate({ key });
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-            Effect.catchTag("BadRequest", () =>
-                Effect.succeed(
-                    FailedAction({
-                        message: `That request was refused. Keys need at least one scope, and each account may hold at most ${MAX_KEYS_PER_USER} keys.`,
-                    })
-                )
-            ),
-            Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+            Effect.catchTag("BadRequest", () => Effect.succeed(FailedAction({ problem: "createRefused" }))),
+            Effect.catch(() => Effect.succeed(FailedAction({ problem: "actionFailed" })))
         ),
 });
 
@@ -176,7 +177,7 @@ const RotateKey = Command.define("RotateKey", {
             return CompletedRotate({ key: rotated });
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-            Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+            Effect.catch(() => Effect.succeed(FailedAction({ problem: "actionFailed" })))
         ),
 });
 
@@ -192,7 +193,7 @@ const SetRevoked = Command.define("SetRevoked", {
             return CompletedSetRevoked({ key: updated });
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-            Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+            Effect.catch(() => Effect.succeed(FailedAction({ problem: "actionFailed" })))
         ),
 });
 
@@ -206,7 +207,7 @@ const DeleteKey = Command.define("DeleteKey", {
             return CompletedDelete();
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-            Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+            Effect.catch(() => Effect.succeed(FailedAction({ problem: "actionFailed" })))
         ),
 });
 
@@ -216,9 +217,7 @@ const CopyKey = Command.define("CopyKey", {
     execute: ({ key }) =>
         Effect.tryPromise(() => navigator.clipboard.writeText(key)).pipe(
             Effect.as(CopiedKey()),
-            Effect.catch(() =>
-                Effect.succeed(FailedAction({ message: "We couldn't reach your clipboard. Please try again." }))
-            )
+            Effect.catch(() => Effect.succeed(FailedAction({ problem: "clipboardFailed" })))
         ),
 });
 
@@ -284,7 +283,7 @@ export const updateKeys = (model: KeysModel, message: KeysMessage): KeysStep =>
                     : [evo(model, { armedDelete: () => Option.some(key), problem: Option.none }), []],
 
             ClickedCopy: ({ key }) => [model, [CopyKey({ key })]],
-            CopiedKey: () => [evo(model, { notice: () => Option.some("Copied to your clipboard.") }), []],
+            CopiedKey: () => [evo(model, { notice: () => Option.some("copied" as const) }), []],
 
             // A fresh credential is the one moment the full key matters, so it
             // arrives unmasked. Every later look at the row is masked.
@@ -292,7 +291,7 @@ export const updateKeys = (model: KeysModel, message: KeysMessage): KeysStep =>
                 evo(refetch(model), {
                     busy: Option.none,
                     form: () => closedForm,
-                    notice: () => Option.some("Key created. It works immediately."),
+                    notice: () => Option.some("created" as const),
                     justMinted: (minted) => [...minted, key.key],
                 }),
                 [FetchKeys()],
@@ -300,8 +299,7 @@ export const updateKeys = (model: KeysModel, message: KeysMessage): KeysStep =>
             CompletedRotate: ({ key }) => [
                 evo(refetch(model), {
                     busy: Option.none,
-                    notice: () =>
-                        Option.some("Key rotated. The old key stopped working the moment the new one was minted."),
+                    notice: () => Option.some("rotated" as const),
                     justMinted: (minted) => [...minted, key.key],
                 }),
                 [FetchKeys()],
@@ -309,20 +307,19 @@ export const updateKeys = (model: KeysModel, message: KeysMessage): KeysStep =>
             CompletedSetRevoked: ({ key }) => [
                 evo(refetch(model), {
                     busy: Option.none,
-                    notice: () =>
-                        Option.some(key.revoked ? "Key revoked. Requests with it now fail." : "Key re-enabled."),
+                    notice: () => Option.some(key.revoked ? ("revoked" as const) : ("reEnabled" as const)),
                 }),
                 [FetchKeys()],
             ],
             CompletedDelete: () => [
                 evo(refetch(model), {
                     busy: Option.none,
-                    notice: () => Option.some("Key deleted."),
+                    notice: () => Option.some("deleted" as const),
                 }),
                 [FetchKeys()],
             ],
 
-            FailedAction: ({ message }) => [evo(model, { busy: Option.none, problem: () => Option.some(message) }), []],
+            FailedAction: ({ problem }) => [evo(model, { busy: Option.none, problem: () => Option.some(problem) }), []],
 
             SignedOutElsewhere: () => [evo(model, { busy: Option.none }), []],
         })
@@ -336,8 +333,8 @@ const scopeLabels: ReadonlyMap<string, string> = new Map(
 
 const maskKey = (key: string): string => `${key.slice(0, 8)}-····-····-····-············`;
 
-const formatDate = (when: DateTime.Utc): string =>
-    DateTime.format(when, { locale: "en-US", month: "long", day: "numeric", year: "numeric" });
+const problemText = (msgs: KeysMessages, problem: KeysProblem): string =>
+    problem === "createRefused" ? msgs.problems.createRefused(MAX_KEYS_PER_USER) : msgs.problems[problem];
 
 const scopeChip = (h: HtmlBuilder<AppMessage>, path: string): Html =>
     h.span(
@@ -345,7 +342,14 @@ const scopeChip = (h: HtmlBuilder<AppMessage>, path: string): Html =>
         [scopeLabels.get(path) ?? path]
     );
 
-const keyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: KeysModel): Html => {
+const keyRow = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: KeysMessages,
+    shared: SharedMessages,
+    language: Language,
+    key: Key,
+    model: KeysModel
+): Html => {
     const busy = Option.contains(model.busy, key.key);
     const minted = model.justMinted.includes(key.key);
     const armed = Option.contains(model.armedDelete, key.key);
@@ -370,7 +374,7 @@ const keyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: KeysModel): Html =>
                     key.revoked
                         ? h.span(
                               [h.Class("font-pixel rounded bg-red-700 px-2 py-1 text-[0.5rem] text-white")],
-                              ["Revoked"]
+                              [shared.revokedBadge]
                           )
                         : h.empty,
                 ]
@@ -386,8 +390,8 @@ const keyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: KeysModel): Html =>
             h.p(
                 [h.Class("font-mono text-base text-gray-500")],
                 [
-                    `Created ${formatDate(key.createdAt)} · Last used ${formatDate(key.lastUsedAt)} · ` +
-                        `${key.rateLimitLimit} requests / ${Math.round(Duration.toSeconds(key.rateLimitWindow))}s`,
+                    `${msgs.createdLastUsed(longDate(language, key.createdAt), longDate(language, key.lastUsedAt))} · ` +
+                        shared.rateLimit(key.rateLimitLimit, Math.round(Duration.toSeconds(key.rateLimitWindow))),
                 ]
             ),
             h.div(
@@ -395,17 +399,17 @@ const keyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: KeysModel): Html =>
                 [
                     h.button(
                         [h.Type("button"), h.Class(smallButton), h.OnClick(ClickedCopy({ key: key.key }))],
-                        ["Copy"]
+                        [msgs.copy]
                     ),
                     h.button(
                         [
                             h.Type("button"),
                             h.Class(smallButton),
                             h.Disabled(busy),
-                            h.Title("Mint a new key for this row; the old key stops working immediately"),
+                            h.Title(msgs.rotateTitle),
                             h.OnClick(ClickedRotate({ key: key.key })),
                         ],
-                        [busy ? "..." : "Rotate"]
+                        [busy ? "..." : msgs.rotate]
                     ),
                     h.button(
                         [
@@ -414,7 +418,7 @@ const keyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: KeysModel): Html =>
                             h.Disabled(busy),
                             h.OnClick(ClickedSetRevoked({ key: key.key, revoked: !key.revoked })),
                         ],
-                        [busy ? "..." : key.revoked ? "Re-enable" : "Revoke"]
+                        [busy ? "..." : key.revoked ? shared.reEnable : shared.revoke]
                     ),
                     h.button(
                         [
@@ -423,7 +427,7 @@ const keyRow = (h: HtmlBuilder<AppMessage>, key: Key, model: KeysModel): Html =>
                             h.Disabled(busy),
                             h.OnClick(ClickedDelete({ key: key.key })),
                         ],
-                        [busy ? "..." : armed ? "Really delete?" : "Delete"]
+                        [busy ? "..." : armed ? shared.reallyDelete : shared.delete]
                     ),
                 ]
             ),
@@ -479,7 +483,7 @@ const elevatedRow = (h: HtmlBuilder<AppMessage>, label: string, description: str
         ]
     );
 
-const createForm = (h: HtmlBuilder<AppMessage>, model: KeysModel): Html => {
+const createForm = (h: HtmlBuilder<AppMessage>, msgs: KeysMessages, shared: SharedMessages, model: KeysModel): Html => {
     const creating = Option.contains(model.busy, "create");
 
     return h.div(
@@ -488,27 +492,24 @@ const createForm = (h: HtmlBuilder<AppMessage>, model: KeysModel): Html => {
             h.label(
                 [h.Class("flex flex-col gap-1")],
                 [
-                    h.span([h.Class("font-pixel text-[0.55rem] text-gray-600")], ["What is this key for?"]),
+                    h.span([h.Class("font-pixel text-[0.55rem] text-gray-600")], [msgs.descriptionLabel]),
                     h.input([
                         h.Type("text"),
                         h.Class(
                             "font-mono focus:border-sky-blue rounded-lg border-2 border-gray-300 bg-white px-3 py-2 text-xl outline-none"
                         ),
-                        h.Placeholder("Optional description, e.g. my tower stats bot"),
+                        h.Placeholder(msgs.descriptionPlaceholder),
                         h.Value(model.form.description),
                         h.OnInput((value) => ChangedDescription({ value })),
                     ]),
                 ]
             ),
-            h.p([h.Class("font-pixel text-[0.55rem] text-gray-600")], ["Read-only scopes (pick at least one)"]),
+            h.p([h.Class("font-pixel text-[0.55rem] text-gray-600")], [msgs.readOnlyScopesLabel]),
             h.div(
                 [h.Class("grid gap-2 sm:grid-cols-2")],
                 SELF_SERVE_SCOPES.map((scope) => scopeCheckbox(h, model, scope.path, scope.label, scope.description))
             ),
-            h.p(
-                [h.Class("font-pixel text-[0.55rem] text-gray-600")],
-                ["Write scopes are granted by hand — reach out on Discord"]
-            ),
+            h.p([h.Class("font-pixel text-[0.55rem] text-gray-600")], [msgs.writeScopesNote]),
             h.div(
                 [h.Class("grid gap-2 sm:grid-cols-2")],
                 ELEVATED_SCOPES.map((scope) => elevatedRow(h, scope.label, scope.description))
@@ -523,7 +524,7 @@ const createForm = (h: HtmlBuilder<AppMessage>, model: KeysModel): Html => {
                             h.Disabled(model.form.scopes.length === 0 || creating),
                             h.OnClick(SubmittedCreate()),
                         ],
-                        [creating ? "..." : "Create key"]
+                        [creating ? "..." : msgs.createKey]
                     ),
                     h.button(
                         [
@@ -532,7 +533,7 @@ const createForm = (h: HtmlBuilder<AppMessage>, model: KeysModel): Html => {
                             h.Disabled(creating),
                             h.OnClick(ClickedCancelCreate()),
                         ],
-                        ["Cancel"]
+                        [shared.cancel]
                     ),
                 ]
             ),
@@ -540,21 +541,22 @@ const createForm = (h: HtmlBuilder<AppMessage>, model: KeysModel): Html => {
     );
 };
 
-const keysSection = (h: HtmlBuilder<AppMessage>, model: KeysModel): Html => {
+const keysSection = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: KeysMessages,
+    shared: SharedMessages,
+    language: Language,
+    model: KeysModel
+): Html => {
     const list = (keys: ReadonlyArray<Key>): Html =>
         h.div(
             [h.Class("flex flex-col gap-4")],
             [
                 ...(keys.length === 0
-                    ? [
-                          h.p(
-                              [h.Class("font-mono text-xl text-gray-600")],
-                              ["No keys yet. Create one and start calling the proxy."]
-                          ),
-                      ]
-                    : keys.map((key) => keyRow(h, key, model))),
+                    ? [h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.emptyState])]
+                    : keys.map((key) => keyRow(h, msgs, shared, language, key, model))),
                 model.form.open
-                    ? createForm(h, model)
+                    ? createForm(h, msgs, shared, model)
                     : h.div(
                           [],
                           [
@@ -565,12 +567,12 @@ const keysSection = (h: HtmlBuilder<AppMessage>, model: KeysModel): Html => {
                                       h.Disabled(keys.length >= MAX_KEYS_PER_USER),
                                       h.Title(
                                           keys.length >= MAX_KEYS_PER_USER
-                                              ? `Each account may hold at most ${MAX_KEYS_PER_USER} keys`
-                                              : "Provision a new key"
+                                              ? msgs.maxKeysTitle(MAX_KEYS_PER_USER)
+                                              : msgs.provisionTitle
                                       ),
                                       h.OnClick(ClickedOpenCreate()),
                                   ],
-                                  ["+ New key"]
+                                  [msgs.newKey]
                               ),
                           ]
                       ),
@@ -580,15 +582,12 @@ const keysSection = (h: HtmlBuilder<AppMessage>, model: KeysModel): Html => {
     return h.section(
         [h.Class(card)],
         [
-            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], ["Your API Keys"]),
-            h.p(
-                [h.Class("font-mono mb-6 text-lg text-gray-500")],
-                ["Rotate any key you may have leaked, and delete the ones you no longer use."]
-            ),
+            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], [msgs.sectionHeading]),
+            h.p([h.Class("font-mono mb-6 text-lg text-gray-500")], [msgs.sectionIntro]),
             AsyncData.match(model.keys, {
-                onIdle: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading your keys..."]),
-                onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading your keys..."]),
-                onFailure: (error) => h.p([h.Class("font-mono text-xl text-red-700")], [error]),
+                onIdle: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loading]),
+                onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loading]),
+                onFailure: () => h.p([h.Class("font-mono text-xl text-red-700")], [msgs.loadFailed]),
                 onRefreshing: list,
                 onStale: ({ data }) => list(data),
                 onSuccess: list,
@@ -597,7 +596,14 @@ const keysSection = (h: HtmlBuilder<AppMessage>, model: KeysModel): Html => {
     );
 };
 
-export const keysView = (h: HtmlBuilder<AppMessage>, model: KeysModel, session: SessionInfo): Html =>
+export const keysView = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: KeysMessages,
+    shared: SharedMessages,
+    language: Language,
+    model: KeysModel,
+    session: SessionInfo
+): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center p-8 pt-24")],
         [
@@ -611,26 +617,26 @@ export const keysView = (h: HtmlBuilder<AppMessage>, model: KeysModel, session: 
                                 [h.Class("font-pixel text-dark-blue text-lg")],
                                 [
                                     Option.match(session.displayName, {
-                                        onSome: (name) => `${name}'s API keys`,
-                                        onNone: () => "Your API keys",
+                                        onSome: (name) => msgs.headingFor(name),
+                                        onNone: () => msgs.heading,
                                     }),
                                 ]
                             ),
                             h.form(
                                 [h.Method("post"), h.Action("/logout")],
-                                [h.button([h.Type("submit"), h.Class(quietButton)], ["Sign out"])]
+                                [h.button([h.Type("submit"), h.Class(quietButton)], [msgs.signOut])]
                             ),
                         ]
                     ),
                     ...Option.match(model.notice, {
-                        onSome: (text) => [banner(h, "notice", text)],
+                        onSome: (notice) => [banner(h, "notice", msgs.notices[notice])],
                         onNone: () => [],
                     }),
                     ...Option.match(model.problem, {
-                        onSome: (text) => [banner(h, "problem", text)],
+                        onSome: (problem) => [banner(h, "problem", problemText(msgs, problem))],
                         onNone: () => [],
                     }),
-                    keysSection(h, model),
+                    keysSection(h, msgs, shared, language, model),
                 ]
             ),
         ]

--- a/apps/authproxy/client/pages/login.ts
+++ b/apps/authproxy/client/pages/login.ts
@@ -1,5 +1,6 @@
 import { Option } from "effect";
 
+import type { LoginMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { appBackLink, card } from "@tinyburg/ui/Chrome";
@@ -12,23 +13,14 @@ import { startLoginHref } from "../routes.ts";
  * could not be completed. Cancelling is not a failure and does not read like
  * one; the rest differ only in what the visitor should try next.
  */
-const problemFor = (error: string): { readonly denied: boolean; readonly text: string } => {
+const problemFor = (msgs: LoginMessages, error: string): { readonly denied: boolean; readonly text: string } => {
     if (error === "oauth_denied") {
-        return {
-            denied: true,
-            text: "Sign in was cancelled. You can pick up where you left off whenever you like.",
-        };
+        return { denied: true, text: msgs.cancelled };
     }
     if (error === "invalid_oauth_cookies" || error === "invalid_oauth_callback") {
-        return {
-            denied: false,
-            text: "That sign in attempt expired or was interrupted. Please start again, and check that your browser allows cookies for this site.",
-        };
+        return { denied: false, text: msgs.interrupted };
     }
-    return {
-        denied: false,
-        text: "We couldn't finish signing you in. Please try again.",
-    };
+    return { denied: false, text: msgs.failed };
 };
 
 const problemBanner = <M>(h: HtmlBuilder<M>, denied: boolean, text: string): Html =>
@@ -44,27 +36,30 @@ const problemBanner = <M>(h: HtmlBuilder<M>, denied: boolean, text: string): Htm
         [text]
     );
 
-export const loginView = <M>(h: HtmlBuilder<M>, returnTo: Option.Option<string>, error: Option.Option<string>): Html =>
+export const loginView = <M>(
+    h: HtmlBuilder<M>,
+    msgs: LoginMessages,
+    shared: SharedMessages,
+    returnTo: Option.Option<string>,
+    error: Option.Option<string>
+): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center justify-center p-8")],
         [
-            appBackLink(h, "/", "← Back to Home"),
+            appBackLink(h, "/", shared.backToHome),
             h.div(
                 [h.Class(card + " max-w-md")],
                 [
                     h.div(
                         [h.Class("mb-8 text-center")],
                         [
-                            h.h1([h.Class("font-pixel mb-2 text-lg text-gray-800")], ["Authproxy Self Service"]),
-                            h.p(
-                                [h.Class("font-mono text-xl text-gray-600")],
-                                ["Your Tinyburg account is your identity here — one sign in, no new password."]
-                            ),
+                            h.h1([h.Class("font-pixel mb-2 text-lg text-gray-800")], [msgs.heading]),
+                            h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.subheading]),
                         ]
                     ),
                     ...Option.match(error, {
                         onSome: (code) => {
-                            const { denied, text } = problemFor(code);
+                            const { denied, text } = problemFor(msgs, code);
                             return [problemBanner(h, denied, text)];
                         },
                         onNone: () => [],
@@ -76,17 +71,17 @@ export const loginView = <M>(h: HtmlBuilder<M>, returnTo: Option.Option<string>,
                                 "bg-dark-blue shadow-pixel hover:shadow-pixel-hover flex w-full items-center justify-center gap-3 rounded-lg px-6 py-4 font-mono text-xl text-white no-underline transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                             ),
                         ],
-                        [towerIcon(h, "h-6 w-6 shrink-0"), h.span([], ["Sign in with Tinyburg"])]
+                        [towerIcon(h, "h-6 w-6 shrink-0"), h.span([], [msgs.signInWithTinyburg])]
                     ),
                     h.p(
                         [h.Class("font-mono mt-6 text-center text-lg text-gray-500")],
                         [
-                            "No Tinyburg account yet? ",
+                            msgs.noAccountBefore,
                             h.a(
                                 [h.Href("https://tinyburg.app/login"), h.Class("text-sky-dark underline")],
-                                ["Create one at tinyburg.app"]
+                                [msgs.createAccountLink]
                             ),
-                            " first.",
+                            msgs.noAccountAfter,
                         ]
                     ),
                 ]

--- a/apps/authproxy/client/pages/notFound.ts
+++ b/apps/authproxy/client/pages/notFound.ts
@@ -1,17 +1,18 @@
+import type { NotFoundMessages, SharedMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { appBackLink, card } from "@tinyburg/ui/Chrome";
 
-export const notFoundView = <M>(h: HtmlBuilder<M>): Html =>
+export const notFoundView = <M>(h: HtmlBuilder<M>, msgs: NotFoundMessages, shared: SharedMessages): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center justify-center p-8")],
         [
-            appBackLink(h, "/", "← Back to Home"),
+            appBackLink(h, "/", shared.backToHome),
             h.div(
                 [h.Class(card + " max-w-md text-center")],
                 [
-                    h.h1([h.Class("font-pixel mb-4 text-lg text-gray-800")], ["404"]),
-                    h.p([h.Class("font-mono text-xl text-gray-600")], ["This floor hasn't been built yet."]),
+                    h.h1([h.Class("font-pixel mb-4 text-lg text-gray-800")], [msgs.heading]),
+                    h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.body]),
                 ]
             ),
         ]

--- a/apps/authproxy/test/pages/home.i18n.test.ts
+++ b/apps/authproxy/test/pages/home.i18n.test.ts
@@ -1,0 +1,48 @@
+import type { SessionState } from "../../client/backend.ts";
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+import { Scene } from "foldkit/test";
+import { describe, it } from "vitest";
+
+import { SignedOut } from "../../client/backend.ts";
+import { messagesFor } from "../../client/messages/index.ts";
+import { homeView } from "../../client/pages/home.ts";
+
+/*
+  The front page rendered in German. This proves the msgs slice actually
+  reaches the view, not that the translation reads well: the selectors are the
+  same `de.*` fields the view was handed, so a page that ignored its slice and
+  kept hardcoded English would fail here.
+*/
+const de = messagesFor("de");
+
+type Model = Readonly<{ session: SessionState }>;
+
+const page = {
+    update: (model: Model, _message: never): readonly [Model, ReadonlyArray<never>] => [model, []],
+    view: (model: Model, h: HtmlBuilder<never>): Html => homeView(h, de.home, model.session),
+};
+
+const signedOut: Model = { session: SignedOut() };
+
+const { expect, given, role, scene } = Scene;
+
+describe("home page in German", () => {
+    it("renders the German copy it was handed", () => {
+        scene(
+            page,
+            given(signedOut),
+            expect(role("heading", { name: de.home.title })).toExist(),
+            expect(role("heading", { name: de.home.howItWorksHeading })).toExist(),
+            expect(role("heading", { name: de.home.testKeysHeading })).toExist()
+        );
+    });
+
+    it("sends a signed out German visitor to the login page", () => {
+        scene(
+            page,
+            given(signedOut),
+            expect(role("link", { name: de.home.signIn })).toHaveAttr("href", "/login?returnTo=%2Fkeys")
+        );
+    });
+});

--- a/apps/authproxy/test/pages/login.test.ts
+++ b/apps/authproxy/test/pages/login.test.ts
@@ -1,0 +1,91 @@
+import { Option } from "effect";
+
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+import { Scene } from "foldkit/test";
+import { describe, it } from "vitest";
+
+import { en } from "../../client/messages/en.ts";
+import { loginView } from "../../client/pages/login.ts";
+
+/*
+  The login page is a pure view: every affordance on it is a server round trip
+  behind an `<a href>`, so there are no Messages and update never runs. The
+  Model is only what `main.ts` reads out of the url and hands to `loginView`.
+
+  Selectors go through `en.*` rather than hardcoded literals, so a copy edit
+  fails in exactly one place.
+*/
+type Model = Readonly<{
+    returnTo: Option.Option<string>;
+    error: Option.Option<string>;
+}>;
+
+const page = {
+    update: (model: Model, _message: never): readonly [Model, ReadonlyArray<never>] => [model, []],
+    view: (model: Model, h: HtmlBuilder<never>): Html => loginView(h, en.login, en.shared, model.returnTo, model.error),
+};
+
+const arriving: Model = { returnTo: Option.none(), error: Option.none() };
+
+const withError = (error: string): Model => ({ ...arriving, error: Option.some(error) });
+
+const { expect, given, role, scene } = Scene;
+
+describe("login page", () => {
+    it("offers the single Tinyburg sign in to someone arriving clean", () => {
+        scene(
+            page,
+            given(arriving),
+            expect(role("heading", { name: en.login.heading })).toExist(),
+            expect(role("link", { name: en.login.signInWithTinyburg })).toHaveAttr("href", "/auth/login"),
+            expect(role("status")).toBeAbsent(),
+            expect(role("alert")).toBeAbsent()
+        );
+    });
+
+    it("carries returnTo through to the sign in link, encoded", () => {
+        scene(
+            page,
+            given({ ...arriving, returnTo: Option.some("/keys") }),
+            expect(role("link", { name: en.login.signInWithTinyburg })).toHaveAttr(
+                "href",
+                "/auth/login?returnTo=%2Fkeys"
+            )
+        );
+    });
+
+    /*
+      Cancelling is not a failure. It gets `role="status"` so a screen reader
+      announces it politely, where everything else gets `role="alert"`.
+    */
+    it("announces a cancelled sign in politely rather than as an error", () => {
+        scene(
+            page,
+            given(withError("oauth_denied")),
+            expect(role("status")).toHaveText(en.login.cancelled),
+            expect(role("alert")).toBeAbsent()
+        );
+    });
+
+    it.each(["invalid_oauth_cookies", "invalid_oauth_callback"])(
+        "tells someone whose round trip lost its footing (%s) to check cookies",
+        (code) => {
+            scene(
+                page,
+                given(withError(code)),
+                expect(role("alert")).toHaveText(en.login.interrupted),
+                expect(role("status")).toBeAbsent()
+            );
+        }
+    );
+
+    it("falls back to try again for an unrecognised code", () => {
+        scene(
+            page,
+            given(withError("some_code_nobody_has_written_yet")),
+            expect(role("alert")).toHaveText(en.login.failed),
+            expect(role("status")).toBeAbsent()
+        );
+    });
+});

--- a/apps/authproxy/tsconfig.json
+++ b/apps/authproxy/tsconfig.json
@@ -12,10 +12,13 @@
         "migrations",
         "routes",
         "shared",
+        "test",
         "cookies.ts",
         "crypto.ts",
         "index.ts",
-        "vite.config.ts"
+        "vite.config.ts",
+        "vitest.config.ts",
+        "vitest.setup.ts"
     ],
     "compilerOptions": {
         "noEmit": true,

--- a/apps/authproxy/vitest.config.ts
+++ b/apps/authproxy/vitest.config.ts
@@ -1,0 +1,23 @@
+import { foldkit } from "@foldkit/vite-plugin";
+import { defineConfig } from "vitest/config";
+
+/*
+  Scene tests render the real views to a vdom and drive them. There is no DOM
+  and no browser: foldkit's runtime schedules through requestAnimationFrame, so
+  booting the whole application under jsdom does not work, and Scene sidesteps
+  the question by never touching a document at all.
+
+  The foldkit plugin is here for the same reason it is in `vite.config.ts`: it
+  stamps view identity onto returned vnodes, which is what makes the differ
+  replace a subtree rather than patch it when the producing function changes.
+  Without it the tests would diff by position and keys, which is not what ships.
+*/
+export default defineConfig({
+    plugins: [foldkit()],
+    test: {
+        name: "authproxy",
+        environment: "node",
+        include: ["test/**/*.test.ts"],
+        setupFiles: ["./vitest.setup.ts"],
+    },
+});

--- a/apps/authproxy/vitest.setup.ts
+++ b/apps/authproxy/vitest.setup.ts
@@ -1,0 +1,6 @@
+import { setup } from "foldkit/test/vitest";
+
+// Registers `toHaveText`, `toBeDisabled`, `toHaveAccessibleName` and the rest
+// of the Scene matchers with `expect`, and augments vitest's `Assertion` type
+// so no `declare module` block is needed at the call sites.
+setup();


### PR DESCRIPTION
Stacked on #98. Typed per-locale message modules for the authproxy client, 94 keys per locale.

- client/messages/{types,en,de,es,fr,index}.ts; language in the Model from navigator.language; msgs threaded through pageView and routeTitle
- Notices/problems/load failures stored in the model became typed tag unions resolved to copy in views (update() has no language)
- keys.ts date site now uses longDate from @tinyburg/ui/Internationalization
- New vitest setup for this app (copied from tinyburg.app) with 8 Scene tests including a de render
- Scope labels in shared/scopes.ts stay English (API endpoint families)
- 16 REVIEW comments mark translations needing human sign-off

