### PR TITLE
Localize the social-circles client (en/de/es/fr)

### DIFF
--- a/apps/social-circles/client/entry.ts
+++ b/apps/social-circles/client/entry.ts
@@ -3,7 +3,7 @@ import "./styles/global.css";
 import { Runtime } from "foldkit";
 
 import { BackendLive } from "./backend.ts";
-import { ChangedUrl, ClickedLink, init, Model, update, view } from "./main.ts";
+import { ChangedUrl, ClickedLink, Model, init, update, view } from "./main.ts";
 import { initialLanguage } from "./messages/index.ts";
 
 const application = Runtime.makeApplication({

--- a/apps/social-circles/client/entry.ts
+++ b/apps/social-circles/client/entry.ts
@@ -3,7 +3,8 @@ import "./styles/global.css";
 import { Runtime } from "foldkit";
 
 import { BackendLive } from "./backend.ts";
-import { ChangedUrl, ClickedLink, Model, init, update, view } from "./main.ts";
+import { ChangedUrl, ClickedLink, init, Model, update, view } from "./main.ts";
+import { initialLanguage } from "./messages/index.ts";
 
 const application = Runtime.makeApplication({
     Model,
@@ -17,5 +18,8 @@ const application = Runtime.makeApplication({
         onUrlChange: (url) => ChangedUrl({ url }),
     },
 });
+
+// index.html is served statically, so the correct `lang` can only be set here.
+document.documentElement.lang = initialLanguage;
 
 Runtime.run(application);

--- a/apps/social-circles/client/main.ts
+++ b/apps/social-circles/client/main.ts
@@ -1,12 +1,15 @@
 import { Effect, Match, Option, Schema as S } from "effect";
 
+import type { TitleMessages } from "./messages/types.ts";
 import type { Document, Html, HtmlBuilder } from "foldkit/html";
 
+import { Language } from "@tinyburg/ui/Internationalization";
 import { AsyncData, Command, Navigation, Render, type Runtime, Url } from "foldkit";
 import { m } from "foldkit/message";
 import { evo } from "foldkit/struct";
 
 import { type Backend, CheckingSession, FetchSession, GotSession, SessionState, SignedOut } from "./backend.ts";
+import { initialLanguage, messagesFor } from "./messages/index.ts";
 import { homeView } from "./pages/home.ts";
 import { loginView } from "./pages/login.ts";
 import { notFoundView } from "./pages/notFound.ts";
@@ -28,6 +31,9 @@ export const Model = S.Struct({
     route: AppRoute,
     session: SessionState,
     towers: TowersModel,
+
+    // Decided once at init from the browser's preferences; nothing changes it.
+    language: Language,
 });
 export type Model = typeof Model.Type;
 
@@ -155,6 +161,7 @@ export const init: Runtime.RoutingApplicationInit<Model, Message, void, Backend>
                 route,
                 session: CheckingSession(),
                 towers: initialTowers,
+                language: initialLanguage,
             },
             route
         )
@@ -164,32 +171,36 @@ export const init: Runtime.RoutingApplicationInit<Model, Message, void, Backend>
 
 // VIEW
 
-const routeTitle = (route: AppRoute): string =>
+const routeTitle = (route: AppRoute, titles: TitleMessages): string =>
     Match.value(route).pipe(
         Match.withReturnType<string>(),
         Match.tagsExhaustive({
-            Home: () => "TinyTower Social Circles | An Opt-In Friend Network Study",
-            Login: () => "Sign In | Social Circles",
-            Towers: () => "Your Towers | Social Circles",
-            Privacy: () => "What You'd Be Sharing | Social Circles",
-            NotFound: () => "Page Not Found | Social Circles",
+            Home: () => titles.home,
+            Login: () => titles.login,
+            Towers: () => titles.towers,
+            Privacy: () => titles.privacy,
+            NotFound: () => titles.notFound,
         })
     );
 
-const pageView = (model: Model, h: HtmlBuilder<Message>): Html =>
-    Match.value(model.route).pipe(
+const pageView = (model: Model, h: HtmlBuilder<Message>): Html => {
+    const msgs = messagesFor(model.language);
+    return Match.value(model.route).pipe(
         Match.withReturnType<Html>(),
         Match.tagsExhaustive({
-            Home: () => homeView(h, model.session),
-            Login: ({ error, returnTo }) => loginView(h, returnTo, error),
+            Home: () => homeView(h, msgs.home, model.session),
+            Login: ({ error, returnTo }) => loginView(h, msgs.login, returnTo, error),
             // The gated page renders nothing until the session answer lands;
             // enterRoute has already sent a signed out visitor to login.
             Towers: () =>
-                model.session._tag === "SignedIn" ? towersView(h, model.towers, model.session.session) : h.empty,
+                model.session._tag === "SignedIn"
+                    ? towersView(h, msgs.towers, model.language, model.towers, model.session.session)
+                    : h.empty,
             Privacy: () => privacyView(h),
-            NotFound: () => notFoundView(h),
+            NotFound: () => notFoundView(h, msgs.notFound),
         })
     );
+};
 
 /**
  * Keys the page wrapper so navigating replaces it outright rather than patching
@@ -201,6 +212,6 @@ const pageKey = (model: Model): string =>
         : model.route._tag;
 
 export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
-    title: routeTitle(model.route),
+    title: routeTitle(model.route, messagesFor(model.language).titles),
     body: h.div([], [h.keyed("div")(pageKey(model), [], [pageView(model, h)])]),
 });

--- a/apps/social-circles/client/messages/de.ts
+++ b/apps/social-circles/client/messages/de.ts
@@ -1,0 +1,111 @@
+/**
+ * German, formal register ("Sie") throughout. Kept in English: Tinyburg,
+ * TinyTower, tinyburg.app, Social Circles (the study's name), and the in-game
+ * setting name "Only Friend Visits". Ordinary words like towers, floors and
+ * friends translate normally.
+ */
+
+import type { Messages } from "./types.ts";
+
+export const de: Messages = {
+    titles: {
+        // REVIEW: subtitle phrasing for "An Opt-In Friend Network Study".
+        home: "TinyTower Social Circles | Eine Opt-in-Studie zum Freundesnetzwerk",
+        login: "Anmelden | Social Circles",
+        towers: "Ihre Türme | Social Circles",
+        privacy: "Was Sie teilen würden | Social Circles",
+        notFound: "Seite nicht gefunden | Social Circles",
+    },
+
+    home: {
+        title: "TinyTower Social Circles",
+        tagline: "Eine Opt-in-Studie darüber, wie TinyTower-Spieler miteinander verbunden sind.",
+        permissionTitle: "Nichts ohne Erlaubnis",
+        permissionBody:
+            "Ihre Freundesliste wird erst gelesen, wenn Sie sich anmelden und zustimmen, und zwar für genau diesen Turm. Sie können jederzeit aufhören und alles löschen.",
+        connectionTitle: "Eine Verbindung braucht beide Seiten",
+        connectionBody:
+            "Wir speichern eine Freundschaft nur, wenn beide Spieler teilnehmen. Wenn Ihr Freund nicht dabei ist, wird diese Verbindung nie gespeichert, nicht einmal als Hinweis.",
+        botTitle: "Kein Bot als Freund nötig",
+        // REVIEW: "Only Friend Visits" kept in English; the game may localize it.
+        botBody:
+            'Ältere Versionen dieser Studie verlangten, ein Bot-Konto als Freund hinzuzufügen. Das ist vorbei. Die Erlaubnis läuft stattdessen über Ihr Tinyburg-Konto, Sie können "Only Friend Visits" also eingeschaltet lassen.',
+        yourTowers: "Ihre Türme →",
+        signIn: "Mit Tinyburg anmelden",
+        whatYoudShare: "Was Sie teilen würden",
+    },
+
+    login: {
+        backToHome: "← Zurück zur Startseite",
+        heading: "Social Circles",
+        intro: "Über die Anmeldung wissen wir, dass ein Turm wirklich Ihnen gehört. Es wird nichts erhoben, bis Sie zustimmen, Turm für Turm.",
+        cancelled: "Die Anmeldung wurde abgebrochen. Es wurde nichts geteilt, und Sie können jederzeit fortfahren.",
+        interrupted:
+            "Dieser Anmeldeversuch ist abgelaufen oder wurde unterbrochen. Bitte beginnen Sie erneut und prüfen Sie, ob Ihr Browser Cookies für diese Seite zulässt.",
+        failed: "Die Anmeldung konnte nicht abgeschlossen werden. Bitte versuchen Sie es erneut.",
+        signInWithTinyburg: "Mit Tinyburg anmelden",
+        noAccountPrefix: "Noch kein Tinyburg-Konto? ",
+        createAccount: "Erstellen Sie zuerst eines auf tinyburg.app",
+        noAccountSuffix: ".",
+    },
+
+    notFound: {
+        heading: "Seite nicht gefunden",
+        body: "Unter dieser Adresse gibt es kein Stockwerk.",
+        backToLobby: "Zurück zur Lobby",
+    },
+
+    towers: {
+        loadFailed:
+            "Wir konnten tinyburg.app nicht erreichen, um zu prüfen, welche Türme Ihnen gehören. Melden Sie sich erneut an; wenn es weiter passiert, ist der Anbieter womöglich nicht erreichbar.",
+        actionFailed: "Das hat nicht geklappt. Bitte versuchen Sie es erneut.",
+        enrollForbidden:
+            "tinyburg.app konnte nicht bestätigen, dass dieser Turm Ihnen gehört. Prüfen Sie, ob er noch mit Ihrem Tinyburg-Konto verknüpft ist.",
+        withdrawNotFound: "Dieser Turm nimmt nicht teil, es gab also nichts zu entfernen.",
+        enrolledCrawled: "Sie nehmen teil. Ihr Kreis steht unten.",
+        enrolledPending:
+            "Sie nehmen teil. Wir konnten Ihren Turm gerade nicht lesen, Ihr Kreis erscheint daher nach dem nächsten planmäßigen Durchlauf.",
+        withdrawn: (eventsRemoved) =>
+            `Entfernt. ${eventsRemoved} ${eventsRemoved === 1 ? "Eintrag über Sie wurde" : "Einträge über Sie wurden"} gelöscht, und Sie nehmen nicht mehr an der Studie teil.`,
+
+        notReadYet: "noch nicht gelesen",
+        lastRead: (date) => `zuletzt gelesen am ${date}`,
+        inTheStudy: (lastCrawled) => `In der Studie · ${lastCrawled}`,
+        circleSummary: (circleSize, totalFriends, lastCrawled) =>
+            `${circleSize} von Ihren ${totalFriends} Freunden ${circleSize === 1 ? "nimmt" : "nehmen"} ebenfalls teil · ${lastCrawled}`,
+        takingPart: "Nimmt teil",
+        notTakingPart: "Nimmt nicht teil",
+        joiningShares:
+            "Beim Beitritt wird nur Ihre Freundesliste geteilt, und nur Verbindungen, bei denen die andere Person ebenfalls beigetreten ist.",
+        seeMyCircle: "Meinen Kreis ansehen",
+        withdrawTitle: "Austreten und alles löschen, was die Studie über diesen Turm gespeichert hat",
+        reallyLeave: "Wirklich austreten und löschen?",
+        leaveAndDelete: "Austreten und meine Daten löschen",
+        joining: "Beitritt läuft...",
+        takePart: "Teilnehmen",
+
+        yourCircle: "Ihr Kreis",
+        hide: "Ausblenden",
+        emptyCircle:
+            "Noch niemand aus Ihrer Freundesliste ist beigetreten. Eine Verbindung erscheint erst, wenn beide Personen teilnehmen.",
+
+        noLinkedTowers: "Sie haben noch kein TinyTower-Konto mit Ihrem Tinyburg-Konto verknüpft.",
+        linkingExplains: "Über die Verknüpfung wissen wir, dass ein Turm wirklich Ihnen gehört. ",
+        linkOne: "Verknüpfen Sie einen auf tinyburg.app",
+        thenComeBack: " und kommen Sie dann zurück.",
+
+        heading: "Ihre Türme",
+        headingBody:
+            "Jeder Turm entscheidet für sich. Bei der Teilnahme wird die Freundesliste dieses Turms geteilt; beim Austritt wird alles gelöscht, was die Studie über ihn gespeichert hat.",
+        loading: "Ihre Türme werden geladen...",
+        // REVIEW: heading uses "Freundeskreise" for the generic sense; the study's
+        // name "Social Circles" stays English elsewhere.
+        yourSocialCircles: "Ihre Freundeskreise",
+        // REVIEW: same choice as yourSocialCircles.
+        namedSocialCircles: (name) => `Freundeskreise von ${name}`,
+        signOut: "Abmelden",
+        privacyPrefix: "Was wir erheben und warum steht auf der ",
+        privacyLink: "Datenschutzseite",
+        privacySuffix: ".",
+    },
+};

--- a/apps/social-circles/client/messages/en.ts
+++ b/apps/social-circles/client/messages/en.ts
@@ -1,0 +1,105 @@
+/**
+ * English. The source copy, moved verbatim from the page modules; the other
+ * locales translate from here. Glossary kept as-is everywhere: Tinyburg,
+ * TinyTower, tinyburg.app, Social Circles (the study's name).
+ */
+
+import type { Messages } from "./types.ts";
+
+export const en: Messages = {
+    titles: {
+        home: "TinyTower Social Circles | An Opt-In Friend Network Study",
+        login: "Sign In | Social Circles",
+        towers: "Your Towers | Social Circles",
+        privacy: "What You'd Be Sharing | Social Circles",
+        notFound: "Page Not Found | Social Circles",
+    },
+
+    home: {
+        title: "TinyTower Social Circles",
+        tagline: "An opt-in study of how TinyTower players are connected.",
+        permissionTitle: "Nothing without permission",
+        permissionBody:
+            "Your friends list is never read until you sign in and say yes, for that specific tower. You can stop and erase everything at any time.",
+        connectionTitle: "A connection needs both people",
+        connectionBody:
+            "We only record a friendship when both players have joined. If your friend hasn't, that connection is never stored, not even as a hint.",
+        botTitle: "No need to friend a bot",
+        botBody:
+            'Older versions of this study needed you to add a bot account. That\'s gone. Permission travels through your Tinyburg account instead, so you can leave "Only Friend Visits" switched on.',
+        yourTowers: "Your towers →",
+        signIn: "Sign in with Tinyburg",
+        whatYoudShare: "What you'd be sharing",
+    },
+
+    login: {
+        backToHome: "← Back to Home",
+        heading: "Social Circles",
+        intro: "Signing in is how we know a tower is really yours. Nothing is collected until you say so, tower by tower.",
+        cancelled: "Sign in was cancelled. Nothing was shared, and you can pick this up whenever you like.",
+        interrupted:
+            "That sign in attempt expired or was interrupted. Please start again, and check that your browser allows cookies for this site.",
+        failed: "We couldn't finish signing you in. Please try again.",
+        signInWithTinyburg: "Sign in with Tinyburg",
+        noAccountPrefix: "No Tinyburg account yet? ",
+        createAccount: "Create one at tinyburg.app",
+        noAccountSuffix: " first.",
+    },
+
+    notFound: {
+        heading: "Page Not Found",
+        body: "There's no floor at this address.",
+        backToLobby: "Back to the lobby",
+    },
+
+    towers: {
+        loadFailed:
+            "We couldn't reach tinyburg.app to check which towers you own. Try signing in again, and if it keeps happening the provider may be down.",
+        actionFailed: "That didn't work. Please try again.",
+        enrollForbidden:
+            "tinyburg.app could not confirm you own that tower. Make sure it is still linked to your Tinyburg account.",
+        withdrawNotFound: "That tower is not taking part, so there was nothing to remove.",
+        enrolledCrawled: "You're taking part. Your circle is below.",
+        enrolledPending:
+            "You're taking part. We couldn't read your tower just now, so your circle will appear after the next scheduled pass.",
+        withdrawn: (eventsRemoved) =>
+            `Removed. ${eventsRemoved} record${eventsRemoved === 1 ? "" : "s"} about you were deleted, and you are no longer in the study.`,
+
+        notReadYet: "not read yet",
+        lastRead: (date) => `last read ${date}`,
+        inTheStudy: (lastCrawled) => `In the study · ${lastCrawled}`,
+        circleSummary: (circleSize, totalFriends, lastCrawled) =>
+            `${circleSize} of your ${totalFriends} friends are also taking part · ${lastCrawled}`,
+        takingPart: "Taking part",
+        notTakingPart: "Not taking part",
+        joiningShares:
+            "Joining shares only your friends list, and only connections where the other person has joined too.",
+        seeMyCircle: "See my circle",
+        withdrawTitle: "Withdraw and delete everything the study holds about this tower",
+        reallyLeave: "Really leave and delete?",
+        leaveAndDelete: "Leave and delete my data",
+        joining: "Joining...",
+        takePart: "Take part",
+
+        yourCircle: "Your circle",
+        hide: "Hide",
+        emptyCircle:
+            "Nobody in your friends list has joined yet. A connection only appears once both people are taking part.",
+
+        noLinkedTowers: "You haven't linked a TinyTower account to your Tinyburg account yet.",
+        linkingExplains: "Linking is how we know a tower is really yours. ",
+        linkOne: "Link one at tinyburg.app",
+        thenComeBack: ", then come back.",
+
+        heading: "Your Towers",
+        headingBody:
+            "Each tower decides for itself. Taking part shares that tower's friends list; leaving erases everything the study holds about it.",
+        loading: "Loading your towers...",
+        yourSocialCircles: "Your social circles",
+        namedSocialCircles: (name) => `${name}'s social circles`,
+        signOut: "Sign out",
+        privacyPrefix: "What we collect and why is written out on the ",
+        privacyLink: "privacy page",
+        privacySuffix: ".",
+    },
+};

--- a/apps/social-circles/client/messages/es.ts
+++ b/apps/social-circles/client/messages/es.ts
@@ -1,0 +1,108 @@
+/**
+ * Spanish, informal register ("tú") throughout. Kept in English: Tinyburg,
+ * TinyTower, tinyburg.app, Social Circles (the study's name), and the in-game
+ * setting name "Only Friend Visits". Ordinary words like towers, floors and
+ * friends translate normally.
+ */
+
+import type { Messages } from "./types.ts";
+
+export const es: Messages = {
+    titles: {
+        // REVIEW: subtitle phrasing for "An Opt-In Friend Network Study".
+        home: "TinyTower Social Circles | Un estudio voluntario de redes de amigos",
+        login: "Iniciar sesión | Social Circles",
+        towers: "Tus torres | Social Circles",
+        privacy: "Qué compartirías | Social Circles",
+        notFound: "Página no encontrada | Social Circles",
+    },
+
+    home: {
+        title: "TinyTower Social Circles",
+        tagline: "Un estudio voluntario sobre cómo se conectan los jugadores de TinyTower.",
+        permissionTitle: "Nada sin permiso",
+        permissionBody:
+            "Tu lista de amigos no se lee hasta que inicias sesión y dices que sí, para esa torre en concreto. Puedes parar y borrarlo todo en cualquier momento.",
+        connectionTitle: "Una conexión necesita a las dos personas",
+        connectionBody:
+            "Solo registramos una amistad cuando ambos jugadores se han unido. Si tu amigo no lo ha hecho, esa conexión nunca se guarda, ni siquiera como pista.",
+        botTitle: "Sin necesidad de agregar un bot",
+        // REVIEW: "Only Friend Visits" kept in English; the game may localize it.
+        botBody:
+            'Las versiones anteriores de este estudio requerían agregar una cuenta bot como amigo. Eso ya no existe. El permiso viaja a través de tu cuenta de Tinyburg, así que puedes dejar activado "Only Friend Visits".',
+        yourTowers: "Tus torres →",
+        signIn: "Inicia sesión con Tinyburg",
+        whatYoudShare: "Qué compartirías",
+    },
+
+    login: {
+        backToHome: "← Volver al inicio",
+        heading: "Social Circles",
+        intro: "Iniciar sesión es cómo sabemos que una torre es realmente tuya. No se recoge nada hasta que tú lo digas, torre por torre.",
+        cancelled: "Se canceló el inicio de sesión. No se compartió nada, y puedes retomarlo cuando quieras.",
+        interrupted:
+            "Ese intento de inicio de sesión caducó o se interrumpió. Empieza de nuevo y comprueba que tu navegador permite cookies para este sitio.",
+        failed: "No pudimos terminar de iniciar tu sesión. Inténtalo de nuevo.",
+        signInWithTinyburg: "Inicia sesión con Tinyburg",
+        noAccountPrefix: "¿Aún no tienes cuenta de Tinyburg? ",
+        createAccount: "Crea una en tinyburg.app",
+        noAccountSuffix: " primero.",
+    },
+
+    notFound: {
+        heading: "Página no encontrada",
+        body: "No hay ningún piso en esta dirección.",
+        backToLobby: "Volver al vestíbulo",
+    },
+
+    towers: {
+        loadFailed:
+            "No pudimos conectar con tinyburg.app para comprobar qué torres son tuyas. Intenta iniciar sesión de nuevo; si sigue pasando, puede que el proveedor esté caído.",
+        actionFailed: "Eso no funcionó. Inténtalo de nuevo.",
+        enrollForbidden:
+            "tinyburg.app no pudo confirmar que esa torre es tuya. Asegúrate de que sigue vinculada a tu cuenta de Tinyburg.",
+        withdrawNotFound: "Esa torre no participa, así que no había nada que eliminar.",
+        enrolledCrawled: "Ya estás participando. Tu círculo está abajo.",
+        enrolledPending:
+            "Ya estás participando. No pudimos leer tu torre ahora mismo, así que tu círculo aparecerá después de la próxima pasada programada.",
+        withdrawn: (eventsRemoved) =>
+            `Eliminado. Se ${eventsRemoved === 1 ? "borró 1 registro" : `borraron ${eventsRemoved} registros`} sobre ti, y ya no formas parte del estudio.`,
+
+        notReadYet: "aún sin leer",
+        lastRead: (date) => `última lectura: ${date}`,
+        inTheStudy: (lastCrawled) => `En el estudio · ${lastCrawled}`,
+        circleSummary: (circleSize, totalFriends, lastCrawled) =>
+            `${circleSize} de tus ${totalFriends} amigos también ${circleSize === 1 ? "participa" : "participan"} · ${lastCrawled}`,
+        takingPart: "Participa",
+        notTakingPart: "No participa",
+        joiningShares:
+            "Unirte comparte solo tu lista de amigos, y solo las conexiones en las que la otra persona también se ha unido.",
+        seeMyCircle: "Ver mi círculo",
+        withdrawTitle: "Retirarse y borrar todo lo que el estudio guarda sobre esta torre",
+        reallyLeave: "¿Seguro que quieres salir y borrar?",
+        leaveAndDelete: "Salir y borrar mis datos",
+        joining: "Uniéndote...",
+        takePart: "Participar",
+
+        yourCircle: "Tu círculo",
+        hide: "Ocultar",
+        emptyCircle:
+            "Nadie de tu lista de amigos se ha unido todavía. Una conexión solo aparece cuando ambas personas participan.",
+
+        noLinkedTowers: "Todavía no has vinculado una cuenta de TinyTower a tu cuenta de Tinyburg.",
+        linkingExplains: "Vincular es cómo sabemos que una torre es realmente tuya. ",
+        linkOne: "Vincula una en tinyburg.app",
+        thenComeBack: " y luego vuelve.",
+
+        heading: "Tus torres",
+        headingBody:
+            "Cada torre decide por sí misma. Participar comparte la lista de amigos de esa torre; salir borra todo lo que el estudio guarda sobre ella.",
+        loading: "Cargando tus torres...",
+        yourSocialCircles: "Tus círculos sociales",
+        namedSocialCircles: (name) => `Círculos sociales de ${name}`,
+        signOut: "Cerrar sesión",
+        privacyPrefix: "Qué recogemos y por qué está explicado en la ",
+        privacyLink: "página de privacidad",
+        privacySuffix: ".",
+    },
+};

--- a/apps/social-circles/client/messages/fr.ts
+++ b/apps/social-circles/client/messages/fr.ts
@@ -1,0 +1,110 @@
+/**
+ * French, informal register ("tu") throughout. Kept in English: Tinyburg,
+ * TinyTower, tinyburg.app, Social Circles (the study's name), and the in-game
+ * setting name "Only Friend Visits". Ordinary words like towers, floors and
+ * friends translate normally.
+ */
+
+import type { Messages } from "./types.ts";
+
+export const fr: Messages = {
+    titles: {
+        // REVIEW: subtitle phrasing for "An Opt-In Friend Network Study".
+        home: "TinyTower Social Circles | Une étude volontaire du réseau d'amis",
+        login: "Connexion | Social Circles",
+        towers: "Tes tours | Social Circles",
+        privacy: "Ce que tu partagerais | Social Circles",
+        notFound: "Page introuvable | Social Circles",
+    },
+
+    home: {
+        title: "TinyTower Social Circles",
+        tagline: "Une étude volontaire sur les liens entre joueurs de TinyTower.",
+        permissionTitle: "Rien sans permission",
+        permissionBody:
+            "Ta liste d'amis n'est jamais lue avant que tu te connectes et que tu dises oui, pour cette tour précise. Tu peux arrêter et tout effacer à tout moment.",
+        connectionTitle: "Une connexion demande deux personnes",
+        connectionBody:
+            "Nous n'enregistrons une amitié que lorsque les deux joueurs ont rejoint l'étude. Si ton ami ne l'a pas fait, cette connexion n'est jamais stockée, pas même comme indice.",
+        botTitle: "Pas besoin d'ajouter un bot en ami",
+        // REVIEW: "Only Friend Visits" kept in English; the game may localize it.
+        botBody:
+            "Les anciennes versions de cette étude demandaient d'ajouter un compte bot en ami. C'est terminé. La permission passe par ton compte Tinyburg, tu peux donc laisser « Only Friend Visits » activé.",
+        yourTowers: "Tes tours →",
+        signIn: "Se connecter avec Tinyburg",
+        whatYoudShare: "Ce que tu partagerais",
+    },
+
+    login: {
+        backToHome: "← Retour à l'accueil",
+        heading: "Social Circles",
+        intro: "La connexion nous permet de savoir qu'une tour est vraiment la tienne. Rien n'est collecté avant que tu le dises, tour par tour.",
+        cancelled: "La connexion a été annulée. Rien n'a été partagé, et tu peux reprendre quand tu veux.",
+        interrupted:
+            "Cette tentative de connexion a expiré ou a été interrompue. Recommence, et vérifie que ton navigateur accepte les cookies pour ce site.",
+        failed: "Nous n'avons pas pu finaliser ta connexion. Réessaie.",
+        signInWithTinyburg: "Se connecter avec Tinyburg",
+        noAccountPrefix: "Pas encore de compte Tinyburg ? ",
+        // REVIEW: imperative with "en" ("crées-en") reads informal on purpose.
+        createAccount: "Crées-en un d'abord sur tinyburg.app",
+        noAccountSuffix: ".",
+    },
+
+    notFound: {
+        heading: "Page introuvable",
+        body: "Il n'y a pas d'étage à cette adresse.",
+        backToLobby: "Retour au hall d'entrée",
+    },
+
+    towers: {
+        loadFailed:
+            "Nous n'avons pas pu joindre tinyburg.app pour vérifier quelles tours t'appartiennent. Essaie de te reconnecter ; si cela continue, le fournisseur est peut-être hors service.",
+        actionFailed: "Ça n'a pas fonctionné. Réessaie.",
+        enrollForbidden:
+            "tinyburg.app n'a pas pu confirmer que cette tour t'appartient. Vérifie qu'elle est toujours liée à ton compte Tinyburg.",
+        withdrawNotFound: "Cette tour ne participe pas, il n'y avait donc rien à retirer.",
+        enrolledCrawled: "Tu participes. Ton cercle est ci-dessous.",
+        enrolledPending:
+            "Tu participes. Nous n'avons pas pu lire ta tour à l'instant, ton cercle apparaîtra donc après le prochain passage planifié.",
+        withdrawn: (eventsRemoved) =>
+            `Supprimé. ${eventsRemoved} enregistrement${eventsRemoved === 1 ? "" : "s"} te concernant ${eventsRemoved === 1 ? "a été supprimé" : "ont été supprimés"}, et tu ne fais plus partie de l'étude.`,
+
+        notReadYet: "pas encore lue",
+        lastRead: (date) => `dernière lecture le ${date}`,
+        inTheStudy: (lastCrawled) => `Dans l'étude · ${lastCrawled}`,
+        circleSummary: (circleSize, totalFriends, lastCrawled) =>
+            `${circleSize} de tes ${totalFriends} amis ${circleSize === 1 ? "participe" : "participent"} aussi · ${lastCrawled}`,
+        takingPart: "Participe",
+        notTakingPart: "Ne participe pas",
+        joiningShares:
+            "Rejoindre ne partage que ta liste d'amis, et seulement les connexions où l'autre personne a aussi rejoint l'étude.",
+        seeMyCircle: "Voir mon cercle",
+        withdrawTitle: "Se retirer et supprimer tout ce que l'étude détient sur cette tour",
+        reallyLeave: "Vraiment quitter et supprimer ?",
+        leaveAndDelete: "Quitter et supprimer mes données",
+        joining: "Inscription...",
+        takePart: "Participer",
+
+        yourCircle: "Ton cercle",
+        hide: "Masquer",
+        emptyCircle:
+            "Personne de ta liste d'amis n'a encore rejoint l'étude. Une connexion n'apparaît que lorsque les deux personnes participent.",
+
+        noLinkedTowers: "Tu n'as pas encore lié de compte TinyTower à ton compte Tinyburg.",
+        linkingExplains: "Le lien nous permet de savoir qu'une tour est vraiment la tienne. ",
+        // REVIEW: imperative with "en" ("lies-en") reads informal on purpose.
+        linkOne: "Lies-en une sur tinyburg.app",
+        thenComeBack: ", puis reviens.",
+
+        heading: "Tes tours",
+        headingBody:
+            "Chaque tour décide pour elle-même. Participer partage la liste d'amis de cette tour ; quitter efface tout ce que l'étude détient sur elle.",
+        loading: "Chargement de tes tours...",
+        yourSocialCircles: "Tes cercles sociaux",
+        namedSocialCircles: (name) => `Les cercles sociaux de ${name}`,
+        signOut: "Se déconnecter",
+        privacyPrefix: "Ce que nous collectons et pourquoi est détaillé sur la ",
+        privacyLink: "page de confidentialité",
+        privacySuffix: ".",
+    },
+};

--- a/apps/social-circles/client/messages/index.ts
+++ b/apps/social-circles/client/messages/index.ts
@@ -1,6 +1,6 @@
 import type { Messages } from "./types.ts";
 
-import { fromNavigator, type Language } from "@tinyburg/ui/Internationalization";
+import { type Language, fromNavigator } from "@tinyburg/ui/Internationalization";
 
 import { de } from "./de.ts";
 import { en } from "./en.ts";

--- a/apps/social-circles/client/messages/index.ts
+++ b/apps/social-circles/client/messages/index.ts
@@ -1,0 +1,23 @@
+import type { Messages } from "./types.ts";
+
+import { fromNavigator, type Language } from "@tinyburg/ui/Internationalization";
+
+import { de } from "./de.ts";
+import { en } from "./en.ts";
+import { es } from "./es.ts";
+import { fr } from "./fr.ts";
+
+const byLanguage: Record<Language, Messages> = { de, en, es, fr };
+
+/** The full message table for a language. Reference-stable per language. */
+export const messagesFor = (language: Language): Messages => byLanguage[language];
+
+/**
+ * The language this visit runs in, decided once at module load from the
+ * browser's preferences. There is no switcher and no persistence, so nothing
+ * ever changes it; commands that produce user-facing text read it directly.
+ * The `typeof navigator` guard keeps node-side imports (tests) working.
+ */
+export const initialLanguage: Language = fromNavigator(
+    typeof navigator === "undefined" ? [] : (navigator.languages ?? [navigator.language])
+);

--- a/apps/social-circles/client/messages/types.ts
+++ b/apps/social-circles/client/messages/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Every user-visible string in the SPA, one interface per page module plus the
+ * document titles. Each locale file implements `Messages` in full, so a string
+ * added here without a translation is a compile error, not a silent fallback.
+ * Interpolated strings are functions of their data.
+ *
+ * Legal prose (`privacy.ts`) is deliberately excluded and stays English.
+ */
+
+export interface TitleMessages {
+    readonly home: string;
+    readonly login: string;
+    readonly towers: string;
+    readonly privacy: string;
+    readonly notFound: string;
+}
+
+export interface HomeMessages {
+    readonly title: string;
+    readonly tagline: string;
+    readonly permissionTitle: string;
+    readonly permissionBody: string;
+    readonly connectionTitle: string;
+    readonly connectionBody: string;
+    readonly botTitle: string;
+    readonly botBody: string;
+    readonly yourTowers: string;
+    readonly signIn: string;
+    readonly whatYoudShare: string;
+}
+
+export interface LoginMessages {
+    readonly backToHome: string;
+    readonly heading: string;
+    readonly intro: string;
+    readonly cancelled: string;
+    readonly interrupted: string;
+    readonly failed: string;
+    readonly signInWithTinyburg: string;
+    readonly noAccountPrefix: string;
+    readonly createAccount: string;
+    readonly noAccountSuffix: string;
+}
+
+export interface NotFoundMessages {
+    readonly heading: string;
+    readonly body: string;
+    readonly backToLobby: string;
+}
+
+export interface TowersMessages {
+    // Command and update strings, surfaced in the notice/problem banners.
+    readonly loadFailed: string;
+    readonly actionFailed: string;
+    readonly enrollForbidden: string;
+    readonly withdrawNotFound: string;
+    readonly enrolledCrawled: string;
+    readonly enrolledPending: string;
+    readonly withdrawn: (eventsRemoved: number) => string;
+
+    // The per-tower row.
+    readonly notReadYet: string;
+    readonly lastRead: (date: string) => string;
+    readonly inTheStudy: (lastCrawled: string) => string;
+    readonly circleSummary: (circleSize: number, totalFriends: number, lastCrawled: string) => string;
+    readonly takingPart: string;
+    readonly notTakingPart: string;
+    readonly joiningShares: string;
+    readonly seeMyCircle: string;
+    readonly withdrawTitle: string;
+    readonly reallyLeave: string;
+    readonly leaveAndDelete: string;
+    readonly joining: string;
+    readonly takePart: string;
+
+    // The expanded circle.
+    readonly yourCircle: string;
+    readonly hide: string;
+    readonly emptyCircle: string;
+
+    // The empty state when no tower is linked.
+    readonly noLinkedTowers: string;
+    readonly linkingExplains: string;
+    readonly linkOne: string;
+    readonly thenComeBack: string;
+
+    // The page frame.
+    readonly heading: string;
+    readonly headingBody: string;
+    readonly loading: string;
+    readonly yourSocialCircles: string;
+    readonly namedSocialCircles: (name: string) => string;
+    readonly signOut: string;
+    readonly privacyPrefix: string;
+    readonly privacyLink: string;
+    readonly privacySuffix: string;
+}
+
+export interface Messages {
+    readonly titles: TitleMessages;
+    readonly home: HomeMessages;
+    readonly login: LoginMessages;
+    readonly notFound: NotFoundMessages;
+    readonly towers: TowersMessages;
+}

--- a/apps/social-circles/client/pages/home.ts
+++ b/apps/social-circles/client/pages/home.ts
@@ -1,4 +1,5 @@
 import type { SessionState } from "../backend.ts";
+import type { HomeMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { card, towerIcon } from "../ui/chrome.ts";
@@ -12,7 +13,7 @@ const point = <M>(h: HtmlBuilder<M>, title: string, body: string): Html =>
         ]
     );
 
-export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
+export const homeView = <M>(h: HtmlBuilder<M>, msgs: HomeMessages, session: SessionState): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center justify-center gap-6 p-8")],
         [
@@ -29,14 +30,8 @@ export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
                                     h.div(
                                         [],
                                         [
-                                            h.h1(
-                                                [h.Class("font-pixel text-dark-blue text-lg")],
-                                                ["TinyTower Social Circles"]
-                                            ),
-                                            h.p(
-                                                [h.Class("font-mono text-xl text-gray-600")],
-                                                ["An opt-in study of how TinyTower players are connected."]
-                                            ),
+                                            h.h1([h.Class("font-pixel text-dark-blue text-lg")], [msgs.title]),
+                                            h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.tagline]),
                                         ]
                                     ),
                                 ]
@@ -45,21 +40,9 @@ export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
                             h.div(
                                 [h.Class("flex flex-col gap-5")],
                                 [
-                                    point(
-                                        h,
-                                        "Nothing without permission",
-                                        "Your friends list is never read until you sign in and say yes, for that specific tower. You can stop and erase everything at any time."
-                                    ),
-                                    point(
-                                        h,
-                                        "A connection needs both people",
-                                        "We only record a friendship when both players have joined. If your friend hasn't, that connection is never stored, not even as a hint."
-                                    ),
-                                    point(
-                                        h,
-                                        "No need to friend a bot",
-                                        'Older versions of this study needed you to add a bot account. That\'s gone. Permission travels through your Tinyburg account instead, so you can leave "Only Friend Visits" switched on.'
-                                    ),
+                                    point(h, msgs.permissionTitle, msgs.permissionBody),
+                                    point(h, msgs.connectionTitle, msgs.connectionBody),
+                                    point(h, msgs.botTitle, msgs.botBody),
                                 ]
                             ),
 
@@ -74,7 +57,7 @@ export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
                                                       "bg-dark-blue shadow-pixel hover:shadow-pixel-hover font-pixel rounded-lg px-6 py-4 text-[0.7rem] text-white no-underline transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                                   ),
                                               ],
-                                              ["Your towers →"]
+                                              [msgs.yourTowers]
                                           )
                                         : h.a(
                                               [
@@ -83,7 +66,7 @@ export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
                                                       "bg-dark-blue shadow-pixel hover:shadow-pixel-hover font-pixel rounded-lg px-6 py-4 text-[0.7rem] text-white no-underline transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                                   ),
                                               ],
-                                              ["Sign in with Tinyburg"]
+                                              [msgs.signIn]
                                           ),
                                     h.a(
                                         [
@@ -92,7 +75,7 @@ export const homeView = <M>(h: HtmlBuilder<M>, session: SessionState): Html =>
                                                 "font-pixel shadow-pixel hover:shadow-pixel-hover rounded-lg border-2 border-gray-300 bg-white px-6 py-4 text-[0.7rem] text-gray-700 no-underline transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                                             ),
                                         ],
-                                        ["What you'd be sharing"]
+                                        [msgs.whatYoudShare]
                                     ),
                                 ]
                             ),

--- a/apps/social-circles/client/pages/login.ts
+++ b/apps/social-circles/client/pages/login.ts
@@ -1,5 +1,6 @@
 import { Option } from "effect";
 
+import type { LoginMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { startLoginHref } from "../routes.ts";
@@ -10,23 +11,14 @@ import { appBackLink, card, towerIcon } from "../ui/chrome.ts";
  * could not be completed. Cancelling is not a failure and does not read like
  * one; the rest differ only in what the visitor should try next.
  */
-const problemFor = (error: string): { readonly denied: boolean; readonly text: string } => {
+const problemFor = (msgs: LoginMessages, error: string): { readonly denied: boolean; readonly text: string } => {
     if (error === "oauth_denied") {
-        return {
-            denied: true,
-            text: "Sign in was cancelled. Nothing was shared, and you can pick this up whenever you like.",
-        };
+        return { denied: true, text: msgs.cancelled };
     }
     if (error === "invalid_oauth_cookies" || error === "invalid_oauth_callback") {
-        return {
-            denied: false,
-            text: "That sign in attempt expired or was interrupted. Please start again, and check that your browser allows cookies for this site.",
-        };
+        return { denied: false, text: msgs.interrupted };
     }
-    return {
-        denied: false,
-        text: "We couldn't finish signing you in. Please try again.",
-    };
+    return { denied: false, text: msgs.failed };
 };
 
 const problemBanner = <M>(h: HtmlBuilder<M>, denied: boolean, text: string): Html =>
@@ -42,29 +34,29 @@ const problemBanner = <M>(h: HtmlBuilder<M>, denied: boolean, text: string): Htm
         [text]
     );
 
-export const loginView = <M>(h: HtmlBuilder<M>, returnTo: Option.Option<string>, error: Option.Option<string>): Html =>
+export const loginView = <M>(
+    h: HtmlBuilder<M>,
+    msgs: LoginMessages,
+    returnTo: Option.Option<string>,
+    error: Option.Option<string>
+): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center justify-center p-8")],
         [
-            appBackLink(h, "/", "← Back to Home"),
+            appBackLink(h, "/", msgs.backToHome),
             h.div(
                 [h.Class(card + " max-w-md")],
                 [
                     h.div(
                         [h.Class("mb-8 text-center")],
                         [
-                            h.h1([h.Class("font-pixel mb-2 text-lg text-gray-800")], ["Social Circles"]),
-                            h.p(
-                                [h.Class("font-mono text-xl text-gray-600")],
-                                [
-                                    "Signing in is how we know a tower is really yours. Nothing is collected until you say so, tower by tower.",
-                                ]
-                            ),
+                            h.h1([h.Class("font-pixel mb-2 text-lg text-gray-800")], [msgs.heading]),
+                            h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.intro]),
                         ]
                     ),
                     ...Option.match(error, {
                         onSome: (code) => {
-                            const { denied, text } = problemFor(code);
+                            const { denied, text } = problemFor(msgs, code);
                             return [problemBanner(h, denied, text)];
                         },
                         onNone: () => [],
@@ -76,17 +68,17 @@ export const loginView = <M>(h: HtmlBuilder<M>, returnTo: Option.Option<string>,
                                 "bg-dark-blue shadow-pixel hover:shadow-pixel-hover flex w-full items-center justify-center gap-3 rounded-lg px-6 py-4 font-mono text-xl text-white no-underline transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                             ),
                         ],
-                        [towerIcon(h, "h-6 w-6 shrink-0"), h.span([], ["Sign in with Tinyburg"])]
+                        [towerIcon(h, "h-6 w-6 shrink-0"), h.span([], [msgs.signInWithTinyburg])]
                     ),
                     h.p(
                         [h.Class("font-mono mt-6 text-center text-lg text-gray-500")],
                         [
-                            "No Tinyburg account yet? ",
+                            msgs.noAccountPrefix,
                             h.a(
                                 [h.Href("https://tinyburg.app/login"), h.Class("text-sky-dark underline")],
-                                ["Create one at tinyburg.app"]
+                                [msgs.createAccount]
                             ),
-                            " first.",
+                            msgs.noAccountSuffix,
                         ]
                     ),
                 ]

--- a/apps/social-circles/client/pages/notFound.ts
+++ b/apps/social-circles/client/pages/notFound.ts
@@ -1,16 +1,17 @@
+import type { NotFoundMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
 import { card } from "../ui/chrome.ts";
 
-export const notFoundView = <M>(h: HtmlBuilder<M>): Html =>
+export const notFoundView = <M>(h: HtmlBuilder<M>, msgs: NotFoundMessages): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center justify-center p-8")],
         [
             h.div(
                 [h.Class(card + " max-w-md text-center")],
                 [
-                    h.h1([h.Class("font-pixel text-dark-blue mb-4 text-lg")], ["Page Not Found"]),
-                    h.p([h.Class("font-mono mb-6 text-xl text-gray-600")], ["There's no floor at this address."]),
+                    h.h1([h.Class("font-pixel text-dark-blue mb-4 text-lg")], [msgs.heading]),
+                    h.p([h.Class("font-mono mb-6 text-xl text-gray-600")], [msgs.body]),
                     h.a(
                         [
                             h.Href("/"),
@@ -18,7 +19,7 @@ export const notFoundView = <M>(h: HtmlBuilder<M>): Html =>
                                 "bg-dark-blue shadow-pixel hover:shadow-pixel-hover font-pixel inline-block rounded-lg px-6 py-4 text-[0.7rem] text-white no-underline transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
                             ),
                         ],
-                        ["Back to the lobby"]
+                        [msgs.backToLobby]
                     ),
                 ]
             ),

--- a/apps/social-circles/client/pages/towers.ts
+++ b/apps/social-circles/client/pages/towers.ts
@@ -1,11 +1,11 @@
-import { Match, Option, Result, Schema as S, Effect } from "effect";
+import { Effect, Match, Option, Result, Schema as S } from "effect";
 
 import type { Message as AppMessage } from "../main.ts";
 import type { TowersMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
-import { type Language, longDate } from "@tinyburg/ui/Internationalization";
 import { PlayerIdSchema } from "@tinyburg/nimblebit-sdk/NimblebitConfig";
+import { type Language, longDate } from "@tinyburg/ui/Internationalization";
 import { AsyncData, Command } from "foldkit";
 import { m } from "foldkit/message";
 import { evo } from "foldkit/struct";

--- a/apps/social-circles/client/pages/towers.ts
+++ b/apps/social-circles/client/pages/towers.ts
@@ -1,8 +1,10 @@
-import { DateTime, Effect, Match, Option, Result, Schema as S } from "effect";
+import { Match, Option, Result, Schema as S, Effect } from "effect";
 
 import type { Message as AppMessage } from "../main.ts";
+import type { TowersMessages } from "../messages/types.ts";
 import type { Html, HtmlBuilder } from "foldkit/html";
 
+import { type Language, longDate } from "@tinyburg/ui/Internationalization";
 import { PlayerIdSchema } from "@tinyburg/nimblebit-sdk/NimblebitConfig";
 import { AsyncData, Command } from "foldkit";
 import { m } from "foldkit/message";
@@ -10,6 +12,7 @@ import { evo } from "foldkit/struct";
 
 import { Circle, TowerStatus } from "../../shared/api.ts";
 import { Self, type SessionInfo } from "../backend.ts";
+import { initialLanguage, messagesFor } from "../messages/index.ts";
 import { banner, card, dangerButton, primaryButton, quietButton } from "../ui/chrome.ts";
 
 type Tower = typeof TowerStatus.Type;
@@ -88,9 +91,10 @@ export type TowersMessage = typeof TowersMessage.Type;
 
 // COMMAND
 
-const LOAD_FAILED =
-    "We couldn't reach tinyburg.app to check which towers you own. Try signing in again, and if it keeps happening the provider may be down.";
-const ACTION_FAILED = "That didn't work. Please try again.";
+// The language is decided once at init and never changes (no switcher), so
+// commands and update may resolve the text they put into the model directly
+// from `initialLanguage` rather than threading it through the runtime.
+const towersMsgs = (): TowersMessages => messagesFor(initialLanguage).towers;
 
 export const FetchTowers = Command.define("FetchTowers", {
     messages: [SettledTowers, SignedOutElsewhere],
@@ -100,7 +104,7 @@ export const FetchTowers = Command.define("FetchTowers", {
         return SettledTowers({ result: Result.succeed(towers) });
     }).pipe(
         Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-        Effect.catch(() => Effect.succeed(SettledTowers({ result: Result.fail(LOAD_FAILED) })))
+        Effect.catch(() => Effect.succeed(SettledTowers({ result: Result.fail(towersMsgs().loadFailed) })))
     ),
 });
 
@@ -114,15 +118,8 @@ const Enroll = Command.define("Enroll", {
             return CompletedEnroll({ crawled: result.crawled });
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-            Effect.catchTag("Forbidden", () =>
-                Effect.succeed(
-                    FailedAction({
-                        message:
-                            "tinyburg.app could not confirm you own that tower. Make sure it is still linked to your Tinyburg account.",
-                    })
-                )
-            ),
-            Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+            Effect.catchTag("Forbidden", () => Effect.succeed(FailedAction({ message: towersMsgs().enrollForbidden }))),
+            Effect.catch(() => Effect.succeed(FailedAction({ message: towersMsgs().actionFailed })))
         ),
 });
 
@@ -136,12 +133,8 @@ const Withdraw = Command.define("Withdraw", {
             return CompletedWithdraw({ eventsRemoved: receipt.eventsRemoved });
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-            Effect.catchTag("NotFound", () =>
-                Effect.succeed(
-                    FailedAction({ message: "That tower is not taking part, so there was nothing to remove." })
-                )
-            ),
-            Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+            Effect.catchTag("NotFound", () => Effect.succeed(FailedAction({ message: towersMsgs().withdrawNotFound }))),
+            Effect.catch(() => Effect.succeed(FailedAction({ message: towersMsgs().actionFailed })))
         ),
 });
 
@@ -155,7 +148,7 @@ const FetchCircle = Command.define("FetchCircle", {
             return SettledCircle({ circle });
         }).pipe(
             Effect.catchTag("Unauthorized", () => Effect.succeed(SignedOutElsewhere())),
-            Effect.catch(() => Effect.succeed(FailedAction({ message: ACTION_FAILED })))
+            Effect.catch(() => Effect.succeed(FailedAction({ message: towersMsgs().actionFailed })))
         ),
 });
 
@@ -186,12 +179,7 @@ export const updateTowers = (model: TowersModel, message: TowersMessage): Towers
             CompletedEnroll: ({ crawled }) => [
                 evo(refetch(model), {
                     busy: Option.none,
-                    notice: () =>
-                        Option.some(
-                            crawled
-                                ? "You're taking part. Your circle is below."
-                                : "You're taking part. We couldn't read your tower just now, so your circle will appear after the next scheduled pass."
-                        ),
+                    notice: () => Option.some(crawled ? towersMsgs().enrolledCrawled : towersMsgs().enrolledPending),
                 }),
                 [FetchTowers()],
             ],
@@ -207,10 +195,7 @@ export const updateTowers = (model: TowersModel, message: TowersMessage): Towers
                 evo(refetch(model), {
                     busy: Option.none,
                     circle: Option.none,
-                    notice: () =>
-                        Option.some(
-                            `Removed. ${eventsRemoved} record${eventsRemoved === 1 ? "" : "s"} about you were deleted, and you are no longer in the study.`
-                        ),
+                    notice: () => Option.some(towersMsgs().withdrawn(eventsRemoved)),
                 }),
                 [FetchTowers()],
             ],
@@ -228,10 +213,10 @@ export const updateTowers = (model: TowersModel, message: TowersMessage): Towers
 
 // VIEW
 
-const formatLastCrawled = (tower: Tower): string =>
+const formatLastCrawled = (msgs: TowersMessages, language: Language, tower: Tower): string =>
     Option.match(tower.lastCrawledAt, {
-        onNone: () => "not read yet",
-        onSome: (when) => `last read ${DateTime.toDateUtc(when).toLocaleDateString()}`,
+        onNone: () => msgs.notReadYet,
+        onSome: (when) => msgs.lastRead(longDate(language, when)),
     });
 
 /**
@@ -241,34 +226,29 @@ const formatLastCrawled = (tower: Tower): string =>
  * "we kept 4 of your 27 friends" is the single most honest thing the study can
  * say about what its data actually is.
  */
-const samplingLine = (h: HtmlBuilder<AppMessage>, tower: Tower): Html =>
+const samplingLine = (h: HtmlBuilder<AppMessage>, msgs: TowersMessages, language: Language, tower: Tower): Html =>
     h.p(
         [h.Class("font-mono text-base text-gray-500")],
         [
             tower.totalFriends === 0
-                ? `In the study · ${formatLastCrawled(tower)}`
-                : `${tower.circleSize} of your ${tower.totalFriends} friends are also taking part · ${formatLastCrawled(tower)}`,
+                ? msgs.inTheStudy(formatLastCrawled(msgs, language, tower))
+                : msgs.circleSummary(tower.circleSize, tower.totalFriends, formatLastCrawled(msgs, language, tower)),
         ]
     );
 
-const circleList = (h: HtmlBuilder<AppMessage>, circle: typeof Circle.Type): Html =>
+const circleList = (h: HtmlBuilder<AppMessage>, msgs: TowersMessages, circle: typeof Circle.Type): Html =>
     h.div(
         [h.Class("mt-3 rounded-lg border-2 border-gray-200 bg-white p-4")],
         [
             h.div(
                 [h.Class("mb-3 flex items-center justify-between gap-3")],
                 [
-                    h.h3([h.Class("font-pixel text-[0.7rem] text-gray-800")], ["Your circle"]),
-                    h.button([h.Type("button"), h.Class(quietButton), h.OnClick(ClickedHideCircle())], ["Hide"]),
+                    h.h3([h.Class("font-pixel text-[0.7rem] text-gray-800")], [msgs.yourCircle]),
+                    h.button([h.Type("button"), h.Class(quietButton), h.OnClick(ClickedHideCircle())], [msgs.hide]),
                 ]
             ),
             circle.friends.length === 0
-                ? h.p(
-                      [h.Class("font-mono text-lg text-gray-600")],
-                      [
-                          "Nobody in your friends list has joined yet. A connection only appears once both people are taking part.",
-                      ]
-                  )
+                ? h.p([h.Class("font-mono text-lg text-gray-600")], [msgs.emptyCircle])
                 : h.div(
                       [h.Class("flex flex-wrap gap-2")],
                       circle.friends.map((friend) =>
@@ -285,7 +265,13 @@ const circleList = (h: HtmlBuilder<AppMessage>, circle: typeof Circle.Type): Htm
         ]
     );
 
-const towerRow = (h: HtmlBuilder<AppMessage>, tower: Tower, model: TowersModel): Html => {
+const towerRow = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: TowersMessages,
+    language: Language,
+    tower: Tower,
+    model: TowersModel
+): Html => {
     const busy = Option.contains(model.busy, tower.playerId);
     const armed = Option.contains(model.armedWithdraw, tower.playerId);
     const showingCircle = Option.match(model.circle, {
@@ -307,7 +293,7 @@ const towerRow = (h: HtmlBuilder<AppMessage>, tower: Tower, model: TowersModel):
                                       "font-mono rounded border-2 border-green-300 bg-green-50 px-2 py-1 text-base text-green-700"
                                   ),
                               ],
-                              ["Taking part"]
+                              [msgs.takingPart]
                           )
                         : h.span(
                               [
@@ -315,19 +301,14 @@ const towerRow = (h: HtmlBuilder<AppMessage>, tower: Tower, model: TowersModel):
                                       "font-mono rounded border-2 border-gray-300 bg-gray-50 px-2 py-1 text-base text-gray-600"
                                   ),
                               ],
-                              ["Not taking part"]
+                              [msgs.notTakingPart]
                           ),
                 ]
             ),
 
             tower.enrolled
-                ? samplingLine(h, tower)
-                : h.p(
-                      [h.Class("font-mono text-base text-gray-500")],
-                      [
-                          "Joining shares only your friends list, and only connections where the other person has joined too.",
-                      ]
-                  ),
+                ? samplingLine(h, msgs, language, tower)
+                : h.p([h.Class("font-mono text-base text-gray-500")], [msgs.joiningShares]),
 
             h.div(
                 [h.Class("flex flex-wrap gap-2")],
@@ -340,17 +321,17 @@ const towerRow = (h: HtmlBuilder<AppMessage>, tower: Tower, model: TowersModel):
                                   h.Disabled(busy),
                                   h.OnClick(ClickedCircle({ playerId: tower.playerId })),
                               ],
-                              [busy ? "..." : "See my circle"]
+                              [busy ? "..." : msgs.seeMyCircle]
                           ),
                           h.button(
                               [
                                   h.Type("button"),
                                   h.Class(dangerButton),
                                   h.Disabled(busy),
-                                  h.Title("Withdraw and delete everything the study holds about this tower"),
+                                  h.Title(msgs.withdrawTitle),
                                   h.OnClick(ClickedWithdraw({ playerId: tower.playerId })),
                               ],
-                              [busy ? "..." : armed ? "Really leave and delete?" : "Leave and delete my data"]
+                              [busy ? "..." : armed ? msgs.reallyLeave : msgs.leaveAndDelete]
                           ),
                       ]
                     : [
@@ -361,7 +342,7 @@ const towerRow = (h: HtmlBuilder<AppMessage>, tower: Tower, model: TowersModel):
                                   h.Disabled(busy),
                                   h.OnClick(ClickedEnroll({ playerId: tower.playerId })),
                               ],
-                              [busy ? "Joining..." : "Take part"]
+                              [busy ? msgs.joining : msgs.takePart]
                           ),
                       ]
             ),
@@ -369,54 +350,51 @@ const towerRow = (h: HtmlBuilder<AppMessage>, tower: Tower, model: TowersModel):
             ...(showingCircle
                 ? Option.match(model.circle, {
                       onNone: () => [],
-                      onSome: (circle) => [circleList(h, circle)],
+                      onSome: (circle) => [circleList(h, msgs, circle)],
                   })
                 : []),
         ]
     );
 };
 
-const towersSection = (h: HtmlBuilder<AppMessage>, model: TowersModel): Html => {
+const towersSection = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: TowersMessages,
+    language: Language,
+    model: TowersModel
+): Html => {
     const list = (towers: ReadonlyArray<Tower>): Html =>
         towers.length === 0
             ? h.div(
                   [h.Class("flex flex-col gap-3")],
                   [
-                      h.p(
-                          [h.Class("font-mono text-xl text-gray-600")],
-                          ["You haven't linked a TinyTower account to your Tinyburg account yet."]
-                      ),
+                      h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.noLinkedTowers]),
                       h.p(
                           [h.Class("font-mono text-lg text-gray-500")],
                           [
-                              "Linking is how we know a tower is really yours. ",
+                              msgs.linkingExplains,
                               h.a(
                                   [h.Href("https://tinyburg.app/account/towers"), h.Class("text-sky-dark underline")],
-                                  ["Link one at tinyburg.app"]
+                                  [msgs.linkOne]
                               ),
-                              ", then come back.",
+                              msgs.thenComeBack,
                           ]
                       ),
                   ]
               )
             : h.div(
                   [h.Class("flex flex-col gap-4")],
-                  towers.map((tower) => towerRow(h, tower, model))
+                  towers.map((tower) => towerRow(h, msgs, language, tower, model))
               );
 
     return h.section(
         [h.Class(card)],
         [
-            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], ["Your Towers"]),
-            h.p(
-                [h.Class("font-mono mb-6 text-lg text-gray-500")],
-                [
-                    "Each tower decides for itself. Taking part shares that tower's friends list; leaving erases everything the study holds about it.",
-                ]
-            ),
+            h.h2([h.Class("font-pixel mb-2 text-lg text-gray-800")], [msgs.heading]),
+            h.p([h.Class("font-mono mb-6 text-lg text-gray-500")], [msgs.headingBody]),
             AsyncData.match(model.towers, {
-                onIdle: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading your towers..."]),
-                onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], ["Loading your towers..."]),
+                onIdle: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loading]),
+                onLoading: () => h.p([h.Class("font-mono text-xl text-gray-600")], [msgs.loading]),
                 onFailure: (error) => h.p([h.Class("font-mono text-xl text-red-700")], [error]),
                 onRefreshing: list,
                 onStale: ({ data }) => list(data),
@@ -426,7 +404,13 @@ const towersSection = (h: HtmlBuilder<AppMessage>, model: TowersModel): Html => 
     );
 };
 
-export const towersView = (h: HtmlBuilder<AppMessage>, model: TowersModel, session: SessionInfo): Html =>
+export const towersView = (
+    h: HtmlBuilder<AppMessage>,
+    msgs: TowersMessages,
+    language: Language,
+    model: TowersModel,
+    session: SessionInfo
+): Html =>
     h.div(
         [h.Class("relative z-10 flex min-h-screen flex-col items-center p-8 pt-24")],
         [
@@ -440,14 +424,14 @@ export const towersView = (h: HtmlBuilder<AppMessage>, model: TowersModel, sessi
                                 [h.Class("font-pixel text-dark-blue text-lg")],
                                 [
                                     Option.match(session.displayName, {
-                                        onSome: (name) => `${name}'s social circles`,
-                                        onNone: () => "Your social circles",
+                                        onSome: (name) => msgs.namedSocialCircles(name),
+                                        onNone: () => msgs.yourSocialCircles,
                                     }),
                                 ]
                             ),
                             h.form(
                                 [h.Method("post"), h.Action("/logout")],
-                                [h.button([h.Type("submit"), h.Class(quietButton)], ["Sign out"])]
+                                [h.button([h.Type("submit"), h.Class(quietButton)], [msgs.signOut])]
                             ),
                         ]
                     ),
@@ -459,13 +443,13 @@ export const towersView = (h: HtmlBuilder<AppMessage>, model: TowersModel, sessi
                         onSome: (text) => [banner(h, "problem", text)],
                         onNone: () => [],
                     }),
-                    towersSection(h, model),
+                    towersSection(h, msgs, language, model),
                     h.p(
                         [h.Class("font-mono text-center text-lg text-white/80")],
                         [
-                            "What we collect and why is written out on the ",
-                            h.a([h.Href("/privacy"), h.Class("text-gold underline")], ["privacy page"]),
-                            ".",
+                            msgs.privacyPrefix,
+                            h.a([h.Href("/privacy"), h.Class("text-gold underline")], [msgs.privacyLink]),
+                            msgs.privacySuffix,
                         ]
                     ),
                 ]

--- a/apps/social-circles/test/pages/home.i18n.test.ts
+++ b/apps/social-circles/test/pages/home.i18n.test.ts
@@ -1,0 +1,40 @@
+import type { SessionState } from "../../client/backend.ts";
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+import { Scene } from "foldkit/test";
+import { describe, it } from "vitest";
+
+import { SignedOut } from "../../client/backend.ts";
+import { de } from "../../client/messages/de.ts";
+import { messagesFor } from "../../client/messages/index.ts";
+import { homeView } from "../../client/pages/home.ts";
+
+/*
+  One localized render, wired exactly the way `main.ts` does it: the view gets
+  the `messagesFor("de")` slice and the assertions select by the German
+  accessible names from `de.home`. This proves the threading, not the
+  translation quality.
+*/
+type Model = Readonly<{ session: SessionState }>;
+
+const page = {
+    update: (model: Model, _message: never): readonly [Model, ReadonlyArray<never>] => [model, []],
+    view: (model: Model, h: HtmlBuilder<never>): Html => homeView(h, messagesFor("de").home, model.session),
+};
+
+const signedOut: Model = { session: SignedOut() };
+
+const { expect, given, role, scene } = Scene;
+
+describe("home page in German", () => {
+    it("renders the German copy for a signed-out visitor", () => {
+        scene(
+            page,
+            given(signedOut),
+            expect(role("heading", { name: de.home.permissionTitle })).toExist(),
+            expect(role("heading", { name: de.home.connectionTitle })).toExist(),
+            expect(role("link", { name: de.home.signIn })).toHaveAttr("href", "/login"),
+            expect(role("link", { name: de.home.whatYoudShare })).toHaveAttr("href", "/privacy")
+        );
+    });
+});

--- a/apps/social-circles/test/pages/login.test.ts
+++ b/apps/social-circles/test/pages/login.test.ts
@@ -1,0 +1,85 @@
+import { Option } from "effect";
+
+import type { Html, HtmlBuilder } from "foldkit/html";
+
+import { Scene } from "foldkit/test";
+import { describe, it } from "vitest";
+
+import { en } from "../../client/messages/en.ts";
+import { loginView } from "../../client/pages/login.ts";
+
+/*
+  The login page is a pure view: every affordance on it is a server round trip
+  behind an `<a href>`, so there are no Messages and update never runs. The
+  selectors go through `en.login` rather than hardcoded literals, so a copy
+  edit fails in exactly one place.
+*/
+type Model = Readonly<{
+    returnTo: Option.Option<string>;
+    error: Option.Option<string>;
+}>;
+
+const page = {
+    update: (model: Model, _message: never): readonly [Model, ReadonlyArray<never>] => [model, []],
+    view: (model: Model, h: HtmlBuilder<never>): Html => loginView(h, en.login, model.returnTo, model.error),
+};
+
+const arriving: Model = { returnTo: Option.none(), error: Option.none() };
+
+const withError = (error: string): Model => ({ ...arriving, error: Option.some(error) });
+
+const { expect, given, role, scene } = Scene;
+
+describe("login page", () => {
+    it("offers the provider sign in to someone arriving clean", () => {
+        scene(
+            page,
+            given(arriving),
+            expect(role("heading", { name: en.login.heading })).toExist(),
+            expect(role("link", { name: en.login.signInWithTinyburg })).toHaveAttr("href", "/auth/login"),
+            expect(role("status")).toBeAbsent(),
+            expect(role("alert")).toBeAbsent()
+        );
+    });
+
+    it("carries returnTo through the provider link, encoded", () => {
+        scene(
+            page,
+            given({ ...arriving, returnTo: Option.some("/towers") }),
+            expect(role("link", { name: en.login.signInWithTinyburg })).toHaveAttr(
+                "href",
+                "/auth/login?returnTo=%2Ftowers"
+            )
+        );
+    });
+
+    it("announces a cancelled sign in politely rather than as an error", () => {
+        scene(
+            page,
+            given(withError("oauth_denied")),
+            expect(role("status")).toHaveText(en.login.cancelled),
+            expect(role("alert")).toBeAbsent()
+        );
+    });
+
+    it.each(["invalid_oauth_cookies", "invalid_oauth_callback"])(
+        "tells someone whose round trip lost its footing (%s) to check cookies",
+        (code) => {
+            scene(
+                page,
+                given(withError(code)),
+                expect(role("alert")).toHaveText(en.login.interrupted),
+                expect(role("status")).toBeAbsent()
+            );
+        }
+    );
+
+    it("falls back to try again for an unrecognised code", () => {
+        scene(
+            page,
+            given(withError("some_code_nobody_has_written_yet")),
+            expect(role("alert")).toHaveText(en.login.failed),
+            expect(role("status")).toBeAbsent()
+        );
+    });
+});

--- a/apps/social-circles/tsconfig.json
+++ b/apps/social-circles/tsconfig.json
@@ -15,11 +15,14 @@
         "routes",
         "services",
         "shared",
+        "test",
         "workflows",
         "cookies.ts",
         "crypto.ts",
         "index.ts",
-        "vite.config.ts"
+        "vite.config.ts",
+        "vitest.config.ts",
+        "vitest.setup.ts"
     ],
     "compilerOptions": {
         "noEmit": true,

--- a/apps/social-circles/vitest.config.ts
+++ b/apps/social-circles/vitest.config.ts
@@ -1,0 +1,23 @@
+import { foldkit } from "@foldkit/vite-plugin";
+import { defineConfig } from "vitest/config";
+
+/*
+  Scene tests render the real views to a vdom and drive them. There is no DOM
+  and no browser: foldkit's runtime schedules through requestAnimationFrame, so
+  booting the whole application under jsdom does not work, and Scene sidesteps
+  the question by never touching a document at all.
+
+  The foldkit plugin is here for the same reason it is in `vite.config.ts`: it
+  stamps view identity onto returned vnodes, which is what makes the differ
+  replace a subtree rather than patch it when the producing function changes.
+  Without it the tests would diff by position and keys, which is not what ships.
+*/
+export default defineConfig({
+    plugins: [foldkit()],
+    test: {
+        name: "social-circles",
+        environment: "node",
+        include: ["test/**/*.test.ts"],
+        setupFiles: ["./vitest.setup.ts"],
+    },
+});

--- a/apps/social-circles/vitest.setup.ts
+++ b/apps/social-circles/vitest.setup.ts
@@ -1,0 +1,6 @@
+import { setup } from "foldkit/test/vitest";
+
+// Registers `toHaveText`, `toBeDisabled`, `toHaveAccessibleName` and the rest
+// of the Scene matchers with `expect`, and augments vitest's `Assertion` type
+// so no `declare module` block is needed at the call sites.
+setup();


### PR DESCRIPTION
Stacked on #98. Typed per-locale message modules for the social-circles client, 65 keys per locale.

- client/messages/{types,en,de,es,fr,index}.ts; language in the Model from navigator.language; msgs threaded through pageView and routeTitle; privacy prose stays English
- towers.ts banner strings from update()/commands resolve via a module-level helper reading the boot-time language (commented; revisit if a live switcher lands, see the tag-union approach in the authproxy PR)
- formatLastCrawled now uses longDate instead of browser-default toLocaleDateString
- New vitest setup with 7 Scene tests including a de render
- 10 REVIEW comments mark translations needing human sign-off

