### PR TITLE
Localize the server-rendered OIDC consent page

### DIFF
--- a/apps/tinyburg.app/server/routes/consentMessages.ts
+++ b/apps/tinyburg.app/server/routes/consentMessages.ts
@@ -1,0 +1,112 @@
+/**
+ * Localized copy for the server-rendered OIDC consent screen.
+ *
+ * Every locale is typed `: ConsentMessages`, so a missing key anywhere is a
+ * compile error. Brand names (Tinyburg, TinyTower) and scope identifiers stay
+ * in English in every locale. Interpolated values (`clientName`, `host`) are
+ * escaped by the caller before they reach these functions.
+ */
+
+import type { Language } from "@tinyburg/ui/Internationalization";
+
+export interface ConsentMessages {
+    /** The document title; receives the already-escaped client name. */
+    readonly title: (clientName: string) => string;
+    /** The lead line under the client's name heading. */
+    readonly wantsAccess: string;
+    /**
+     * What each scope means, in the second person, for the consent screen.
+     *
+     * These are the words a player decides on, so they say what the
+     * application gains rather than naming the endpoints it unlocks.
+     * `offline_access` in particular has to be honest that the application
+     * keeps working once the browser is closed, because that is the part
+     * nobody expects.
+     */
+    readonly scopeDescriptions: Record<string, string>;
+    /** The approve button label. */
+    readonly authorize: string;
+    /** The deny button label. */
+    readonly cancel: string;
+    /** The footer line naming the redirect destination; receives the already-escaped host. */
+    readonly destination: (host: string) => string;
+}
+
+const en: ConsentMessages = {
+    title: (clientName) => `Authorize ${clientName} | Tinyburg`,
+    wantsAccess: "wants to access your Tinyburg account",
+    scopeDescriptions: {
+        openid: "Confirm your Tinyburg identity",
+        profile: "See your display name and avatar",
+        towers: "See and manage the TinyTower saves you have linked",
+        "towers:read": "See the TinyTower saves you have linked, without changing them",
+        "towers:write": "Change the TinyTower saves you have linked, including uploading saves and entering raffles",
+        offline_access: "Keep doing this in the background, even when you are not using it",
+    },
+    authorize: "Authorize",
+    cancel: "Cancel",
+    destination: (host) => `After authorizing you'll be sent back to ${host}`,
+};
+
+// German: formal register ("Sie"). Tinyburg, TinyTower, and scope identifiers stay in English.
+const de: ConsentMessages = {
+    title: (clientName) => `${clientName} autorisieren | Tinyburg`,
+    wantsAccess: "möchte auf Ihr Tinyburg-Konto zugreifen",
+    scopeDescriptions: {
+        openid: "Ihre Tinyburg-Identität bestätigen",
+        profile: "Ihren Anzeigenamen und Avatar sehen",
+        towers: "Die von Ihnen verknüpften TinyTower-Spielstände sehen und verwalten",
+        "towers:read": "Die von Ihnen verknüpften TinyTower-Spielstände sehen, ohne sie zu verändern",
+        // REVIEW: consent-critical wording for save uploads and raffle entry
+        "towers:write":
+            "Die von Ihnen verknüpften TinyTower-Spielstände verändern, einschließlich des Hochladens von Spielständen und der Teilnahme an Verlosungen",
+        // REVIEW: consent-critical wording for background access while signed out
+        offline_access: "Dies auch im Hintergrund weiter tun, selbst wenn Sie die Anwendung gerade nicht verwenden",
+    },
+    authorize: "Autorisieren",
+    cancel: "Abbrechen",
+    destination: (host) => `Nach der Autorisierung werden Sie zurück zu ${host} geleitet`,
+};
+
+// Spanish: informal register ("tú"). Tinyburg, TinyTower, and scope identifiers stay in English.
+const es: ConsentMessages = {
+    title: (clientName) => `Autorizar ${clientName} | Tinyburg`,
+    wantsAccess: "quiere acceder a tu cuenta de Tinyburg",
+    scopeDescriptions: {
+        openid: "Confirmar tu identidad de Tinyburg",
+        profile: "Ver tu nombre visible y tu avatar",
+        towers: "Ver y gestionar las partidas de TinyTower que has vinculado",
+        "towers:read": "Ver las partidas de TinyTower que has vinculado, sin modificarlas",
+        // REVIEW: consent-critical wording for save uploads and raffle entry
+        "towers:write":
+            "Modificar las partidas de TinyTower que has vinculado, incluyendo subir partidas y participar en sorteos",
+        // REVIEW: consent-critical wording for background access while signed out
+        offline_access: "Seguir haciendo esto en segundo plano, incluso cuando no la estés usando",
+    },
+    authorize: "Autorizar",
+    cancel: "Cancelar",
+    destination: (host) => `Después de autorizar volverás a ${host}`,
+};
+
+// French: informal register ("tu"). Tinyburg, TinyTower, and scope identifiers stay in English.
+const fr: ConsentMessages = {
+    title: (clientName) => `Autoriser ${clientName} | Tinyburg`,
+    wantsAccess: "veut accéder à ton compte Tinyburg",
+    scopeDescriptions: {
+        openid: "Confirmer ton identité Tinyburg",
+        profile: "Voir ton nom d'affichage et ton avatar",
+        towers: "Voir et gérer les sauvegardes TinyTower que tu as liées",
+        "towers:read": "Voir les sauvegardes TinyTower que tu as liées, sans les modifier",
+        // REVIEW: consent-critical wording for save uploads and raffle entry
+        "towers:write":
+            "Modifier les sauvegardes TinyTower que tu as liées, y compris téléverser des sauvegardes et participer aux tirages au sort",
+        // REVIEW: consent-critical wording for background access while signed out
+        offline_access: "Continuer à le faire en arrière-plan, même quand tu ne l'utilises pas",
+    },
+    authorize: "Autoriser",
+    cancel: "Annuler",
+    // REVIEW: "renvoyé" is masculine-default; no gender-neutral form fits this line naturally
+    destination: (host) => `Après l'autorisation, tu seras renvoyé vers ${host}`,
+};
+
+export const consentMessagesFor: Record<Language, ConsentMessages> = { de, en, es, fr };

--- a/apps/tinyburg.app/server/routes/oidc.ts
+++ b/apps/tinyburg.app/server/routes/oidc.ts
@@ -8,6 +8,7 @@ import * as crypto from "node:crypto";
 import type { OAuthAuthorizationRequest, OAuthClient } from "../../domain/models.ts";
 
 import { TOWERS_READ_SCOPE, TOWERS_SCOPE, TOWERS_WRITE_SCOPE } from "@tinyburg/trading-sdk/Sdk";
+import { type Language, fromAcceptLanguage } from "@tinyburg/ui/Internationalization";
 import { Jwt, Oidc } from "effect-oidc";
 
 import { DevelopersRepository } from "../../domain/developers.ts";
@@ -17,6 +18,7 @@ import { UsersRepository } from "../../domain/users.ts";
 import { maybeCurrentUser } from "../cookies.ts";
 import { sha256 } from "../crypto.ts";
 import { OidcKeys } from "../keys.ts";
+import { consentMessagesFor } from "./consentMessages.ts";
 
 const ACCESS_TOKEN_TTL_SECONDS = 900;
 const ID_TOKEN_TTL_SECONDS = 900;
@@ -43,7 +45,9 @@ const newOpaqueToken = (): string => crypto.randomUUID() + crypto.randomUUID();
 const noStore = { "cache-control": "no-store", pragma: "no-cache" };
 
 /** A plain-text page for authorize errors that must never reach the client's
- *  redirect uri (unknown client, unregistered redirect, malformed request). */
+ *  redirect uri (unknown client, unregistered redirect, malformed request).
+ *  Intentionally untranslated: OAuth protocol errors are developer-facing and
+ *  stay English by convention. */
 const badRequest = (message: string) => HttpServerResponse.text(message, { status: 400 });
 
 const tokenError = (status: number, error: string) => HttpServerResponse.json({ error }, { status, headers: noStore });
@@ -135,35 +139,19 @@ const escapeHtml = (value: string): string =>
     value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 
 /**
- * What each scope means, in the second person, for the consent screen.
- *
- * These are the words a player decides on, so they say what the application
- * gains rather than naming the endpoints it unlocks. `offline_access` in
- * particular has to be honest that the application keeps working once the
- * browser is closed, because that is the part nobody expects.
- */
-const scopeDescriptions: Record<string, string> = {
-    openid: "Confirm your Tinyburg identity",
-    profile: "See your display name and avatar",
-    towers: "See and manage the TinyTower saves you have linked",
-    "towers:read": "See the TinyTower saves you have linked, without changing them",
-    "towers:write": "Change the TinyTower saves you have linked, including uploading saves and entering raffles",
-    offline_access: "Keep doing this in the background, even when you are not using it",
-};
-
-/**
  * The consent screen is server-rendered rather than a SPA route: during a
  * third-party authorization the browser holds no access token for the SPA to
  * authenticate with, only the provider session cookie this page runs on.
  */
-const consentPage = (client: OAuthClient, request: OAuthAuthorizationRequest) =>
-    HttpServerResponse.html(
+const consentPage = (client: OAuthClient, request: OAuthAuthorizationRequest, language: Language) => {
+    const msgs = consentMessagesFor[language];
+    return HttpServerResponse.html(
         `<!doctype html>
-<html lang="en">
+<html lang="${language}">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
-<title>Authorize ${escapeHtml(client.name)} | Tinyburg</title>
+<title>${msgs.title(escapeHtml(client.name))}</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <style>
   :root { color-scheme: light }
@@ -188,22 +176,23 @@ const consentPage = (client: OAuthClient, request: OAuthAuthorizationRequest) =>
 <body>
   <main class="card">
     <h1>${escapeHtml(client.name)}</h1>
-    <p class="lead">wants to access your Tinyburg account</p>
+    <p class="lead">${msgs.wantsAccess}</p>
     <ul>
       ${scopesOf(request.scope)
-          .map((scope) => `<li>✅ ${escapeHtml(scopeDescriptions[scope] ?? scope)}</li>`)
+          .map((scope) => `<li>✅ ${escapeHtml(msgs.scopeDescriptions[scope] ?? scope)}</li>`)
           .join("\n      ")}
     </ul>
     <form method="post" action="/oauth/consent" class="row">
       <input type="hidden" name="request_id" value="${escapeHtml(request.id)}" />
-      <button class="approve" type="submit" name="decision" value="approve">Authorize</button>
-      <button class="deny" type="submit" name="decision" value="deny">Cancel</button>
+      <button class="approve" type="submit" name="decision" value="approve">${msgs.authorize}</button>
+      <button class="deny" type="submit" name="decision" value="deny">${msgs.cancel}</button>
     </form>
-    <p class="dest">After authorizing you'll be sent back to ${escapeHtml(new URL(request.redirectUri).host)}</p>
+    <p class="dest">${msgs.destination(escapeHtml(new URL(request.redirectUri).host))}</p>
   </main>
 </body>
 </html>`
     ).pipe(HttpServerResponse.setHeader("cache-control", "no-store"));
+};
 
 // GET /oauth/authorize - the browser entry point of the code flow. Visitors
 // without a provider session bounce through /login and come back here; bad
@@ -257,7 +246,10 @@ const authorize = Effect.gen(function* () {
     // Every third party asks permission on every authorization; consent is
     // never remembered. The first party is the app the visitor is already
     // using, so prompting it to authorize itself would be noise.
-    if (client.id !== DevelopersRepository.FIRST_PARTY_CLIENT_ID) return consentPage(client, created);
+    if (client.id !== DevelopersRepository.FIRST_PARTY_CLIENT_ID) {
+        const language = fromAcceptLanguage(request.headers["accept-language"]);
+        return consentPage(client, created, language);
+    }
 
     const redirect = yield* issueAuthorizationCode(created, user.id);
     return Option.match(redirect, {


### PR DESCRIPTION
Stacked on #98. The consent page now renders in en/de/es/fr negotiated from Accept-Language.

- New server/routes/consentMessages.ts: ConsentMessages interface, four locales, scope descriptions moved from oidc.ts
- consentPage takes the language, emits matching html lang, escaping unchanged
- Plain-text OAuth protocol errors intentionally stay English (developer-facing)
- 7 REVIEW comments mark tone-sensitive consent copy

