### PR TITLE
Localize Discord bot replies and OAuth result pages

### DIFF
--- a/apps/discord-bot/interactions.ts
+++ b/apps/discord-bot/interactions.ts
@@ -1,12 +1,14 @@
 import { Effect, Layer, Option, Result } from "effect";
 import { Url } from "effect/unstable/http";
 
+import { fromDiscordLocale } from "@tinyburg/ui/Internationalization";
 import { Discord, Ix, UI } from "dfx";
 import { InteractionsRegistry } from "dfx/gateway";
 import { Oidc } from "effect-oidc";
 
 import { randomSecret, sha256 } from "./crypto.ts";
 import { LinksRepository } from "./domain/links.ts";
+import { botMessagesFor } from "./messages.ts";
 import { LINK_SCOPES, tinyburgConfig } from "./tinyburg.ts";
 
 /**
@@ -19,6 +21,11 @@ import { LINK_SCOPES, tinyburgConfig } from "./tinyburg.ts";
  * `contexts` and `integration_types` let the commands run in a guild, in the
  * bot's DMs, or as a user-installed app, so someone can link privately
  * without a server admin having to install anything.
+ *
+ * Replies are localized from `interaction.locale`; the command names and
+ * descriptions below deliberately stay English. Discord localizes those
+ * through its own `name_localizations` / `description_localizations`
+ * registration fields, which are out of scope here.
  */
 
 const INTEGRATION_TYPES = [
@@ -78,6 +85,16 @@ const invokingUserId = Effect.map(Ix.Interaction, (interaction) =>
     Option.fromNullishOr(interaction.member?.user.id ?? interaction.user?.id)
 );
 
+/**
+ * What language to reply in. Discord guarantees `locale` on every
+ * application command interaction; the `in` check only narrows away the PING
+ * interaction, whose type omits the field and which never reaches a handler.
+ */
+const interactionMessages = Effect.map(
+    Ix.Interaction,
+    (interaction) => botMessagesFor[fromDiscordLocale("locale" in interaction ? interaction.locale : undefined)]
+);
+
 export const InteractionsLive = Layer.effectDiscard(
     Effect.gen(function* () {
         const registry = yield* InteractionsRegistry;
@@ -96,15 +113,16 @@ export const InteractionsLive = Layer.effectDiscard(
                 contexts: CONTEXTS,
             },
             Effect.gen(function* () {
+                const messages = yield* interactionMessages;
                 const discordUserId = yield* invokingUserId;
                 if (Option.isNone(discordUserId)) {
-                    return ephemeral("I could not tell who ran that command.");
+                    return ephemeral(messages.unknownInvoker);
                 }
 
                 const existing = yield* links.findLinkByDiscordUserId(discordUserId.value);
                 if (Option.isSome(existing)) {
-                    const name = Option.getOrElse(existing.value.displayName, () => "a Tinyburg account");
-                    return ephemeral(`This Discord account is already linked to **${name}**. Run \`/unlink\` first.`);
+                    const name = Option.getOrElse(existing.value.displayName, () => messages.fallbackAccountName);
+                    return ephemeral(messages.alreadyLinked(name));
                 }
 
                 const state = randomSecret();
@@ -139,12 +157,8 @@ export const InteractionsLive = Layer.effectDiscard(
                 });
 
                 return ephemeralWithLink({
-                    content: [
-                        "Sign in at tinyburg.app to link your account. This link works once and expires in 10 minutes.",
-                        "",
-                        "It only asks to confirm who you are: your towers stay private until you grant that separately.",
-                    ].join("\n"),
-                    label: "Link my Tinyburg account",
+                    content: messages.linkPrompt,
+                    label: messages.linkButtonLabel,
                     url: authorizationUrl.href,
                 });
             })
@@ -167,23 +181,28 @@ export const InteractionsLive = Layer.effectDiscard(
             },
             (context) =>
                 Effect.gen(function* () {
+                    const messages = yield* interactionMessages;
                     const invokerId = yield* invokingUserId;
                     if (Option.isNone(invokerId)) {
-                        return ephemeral("I could not tell who ran that command.");
+                        return ephemeral(messages.unknownInvoker);
                     }
 
                     const target = context.optionValueOptional("user").pipe(Option.getOrElse(() => invokerId.value));
+                    const askingAboutSelf = target === invokerId.value;
 
                     const found = yield* links.findLinkByDiscordUserId(target);
-                    const subject = target === invokerId.value ? "You have" : `<@${target}> has`;
-
                     if (Option.isNone(found)) {
-                        const hint = target === invokerId.value ? " Run `/link` to connect one." : "";
-                        return ephemeral(`${subject} not linked a Tinyburg account.${hint}`);
+                        return ephemeral(
+                            askingAboutSelf ? messages.whoisSelfNotLinked : messages.whoisOtherNotLinked(`<@${target}>`)
+                        );
                     }
 
-                    const name = Option.getOrElse(found.value.displayName, () => "a Tinyburg account");
-                    return ephemeral(`${subject} linked **${name}**.`);
+                    const name = Option.getOrElse(found.value.displayName, () => messages.fallbackAccountName);
+                    return ephemeral(
+                        askingAboutSelf
+                            ? messages.whoisSelfLinked(name)
+                            : messages.whoisOtherLinked(`<@${target}>`, name)
+                    );
                 })
         );
 
@@ -195,16 +214,15 @@ export const InteractionsLive = Layer.effectDiscard(
                 contexts: CONTEXTS,
             },
             Effect.gen(function* () {
+                const messages = yield* interactionMessages;
                 const discordUserId = yield* invokingUserId;
                 if (Option.isNone(discordUserId)) {
-                    return ephemeral("I could not tell who ran that command.");
+                    return ephemeral(messages.unknownInvoker);
                 }
 
                 const removed = yield* links.deleteLinkByDiscordUserId(discordUserId.value);
 
-                return Option.isNone(removed)
-                    ? ephemeral("This Discord account is not linked to a Tinyburg account.")
-                    : ephemeral("Unlinked. Your Tinyburg account no longer answers to this Discord account.");
+                return Option.isNone(removed) ? ephemeral(messages.notLinked) : ephemeral(messages.unlinked);
             })
         );
 

--- a/apps/discord-bot/messages.ts
+++ b/apps/discord-bot/messages.ts
@@ -1,0 +1,161 @@
+import type { Language } from "@tinyburg/ui/Internationalization";
+
+/**
+ * Every user-facing string the bot produces, per language.
+ *
+ * The `: BotMessages` annotation on each locale is the completeness check: a
+ * key missing from any locale is a compile error. Interpolated strings are
+ * functions so each language controls its own word order.
+ *
+ * The `/whois` reply is modelled as four full sentences rather than a
+ * composed subject + predicate: gluing "You have" / "<@id> has" onto a shared
+ * tail does not survive translation (word order, case, agreement all shift).
+ *
+ * Glossary kept in English everywhere: Tinyburg, TinyTower, bitizen(s), bux,
+ * Discord, and the slash-command names (`/link`, `/unlink`, `/whois`).
+ */
+export interface BotMessages {
+    // Interaction replies
+    readonly unknownInvoker: string;
+    readonly alreadyLinked: (name: string) => string;
+    readonly fallbackAccountName: string;
+    readonly linkPrompt: string;
+    readonly linkButtonLabel: string;
+    readonly whoisSelfNotLinked: string;
+    readonly whoisOtherNotLinked: (mention: string) => string;
+    readonly whoisSelfLinked: (name: string) => string;
+    readonly whoisOtherLinked: (mention: string, name: string) => string;
+    readonly notLinked: string;
+    readonly unlinked: string;
+    readonly linkedFollowUp: (name: string) => string;
+    readonly fallbackYourAccountName: string;
+    // OAuth result pages (bodies are HTML fragments; `name` is interpolated
+    // with exactly the escaping the caller applied, none today)
+    readonly linkedTitle: string;
+    readonly linkedBody: (name: string) => string;
+    readonly failedTitle: string;
+    readonly failedBody: string;
+    readonly cancelledTitle: string;
+    readonly cancelledBody: string;
+}
+
+const en: BotMessages = {
+    unknownInvoker: "I could not tell who ran that command.",
+    alreadyLinked: (name) => `This Discord account is already linked to **${name}**. Run \`/unlink\` first.`,
+    fallbackAccountName: "a Tinyburg account",
+    linkPrompt: [
+        "Sign in at tinyburg.app to link your account. This link works once and expires in 10 minutes.",
+        "",
+        "It only asks to confirm who you are: your towers stay private until you grant that separately.",
+    ].join("\n"),
+    linkButtonLabel: "Link my Tinyburg account",
+    whoisSelfNotLinked: "You have not linked a Tinyburg account. Run `/link` to connect one.",
+    whoisOtherNotLinked: (mention) => `${mention} has not linked a Tinyburg account.`,
+    whoisSelfLinked: (name) => `You have linked **${name}**.`,
+    whoisOtherLinked: (mention, name) => `${mention} has linked **${name}**.`,
+    notLinked: "This Discord account is not linked to a Tinyburg account.",
+    unlinked: "Unlinked. Your Tinyburg account no longer answers to this Discord account.",
+    linkedFollowUp: (name) => `Linked to **${name}**.`,
+    fallbackYourAccountName: "your Tinyburg account",
+    linkedTitle: "Linked",
+    linkedBody: (name) =>
+        `Your Tinyburg account <strong>${name}</strong> is now linked to Discord. You can close this tab and go back.`,
+    failedTitle: "Could not link",
+    failedBody:
+        "That link did not work. It may have expired or already been used. Run <strong>/link</strong> in Discord to start again.",
+    cancelledTitle: "Not linked",
+    cancelledBody: "Nothing was linked. You can run <strong>/link</strong> in Discord if you change your mind.",
+};
+
+// German. Register: formal "Sie". Every template that can receive
+// `fallbackAccountName` phrases the account as "mit ... verknüpft" so the
+// dative "einem Tinyburg-Konto" fits each slot.
+const de: BotMessages = {
+    unknownInvoker: "Ich konnte nicht erkennen, wer diesen Befehl ausgeführt hat.",
+    alreadyLinked: (name) =>
+        `Dieses Discord-Konto ist bereits mit **${name}** verknüpft. Führen Sie zuerst \`/unlink\` aus.`,
+    fallbackAccountName: "einem Tinyburg-Konto", // REVIEW: declined for the dative slots ("mit ... verknüpft") it is interpolated into
+    linkPrompt: [
+        "Melden Sie sich auf tinyburg.app an, um Ihr Konto zu verknüpfen. Dieser Link funktioniert nur einmal und läuft in 10 Minuten ab.",
+        "",
+        "Er bestätigt nur, wer Sie sind: Ihre Türme bleiben privat, bis Sie den Zugriff separat gewähren.",
+    ].join("\n"),
+    linkButtonLabel: "Mein Tinyburg-Konto verknüpfen",
+    whoisSelfNotLinked: "Sie haben kein Tinyburg-Konto verknüpft. Führen Sie `/link` aus, um eines zu verbinden.",
+    whoisOtherNotLinked: (mention) => `${mention} hat kein Tinyburg-Konto verknüpft.`,
+    whoisSelfLinked: (name) => `Sie sind mit **${name}** verknüpft.`,
+    whoisOtherLinked: (mention, name) => `${mention} ist mit **${name}** verknüpft.`,
+    notLinked: "Dieses Discord-Konto ist mit keinem Tinyburg-Konto verknüpft.",
+    unlinked: "Verknüpfung aufgehoben. Ihr Tinyburg-Konto ist nicht mehr mit diesem Discord-Konto verbunden.", // REVIEW: the English "no longer answers to" whimsy is flattened
+    linkedFollowUp: (name) => `Mit **${name}** verknüpft.`,
+    fallbackYourAccountName: "Ihrem Tinyburg-Konto", // REVIEW: declined for the dative slots ("Mit ... verknüpft"); reads doubled inside linkedBody, as in English
+    linkedTitle: "Verknüpft",
+    linkedBody: (name) =>
+        `Ihr Tinyburg-Konto <strong>${name}</strong> ist jetzt mit Discord verknüpft. Sie können diesen Tab schließen und zurückkehren.`,
+    failedTitle: "Verknüpfung fehlgeschlagen",
+    failedBody:
+        "Dieser Link hat nicht funktioniert. Er ist möglicherweise abgelaufen oder wurde bereits verwendet. Führen Sie <strong>/link</strong> in Discord aus, um neu zu beginnen.",
+    cancelledTitle: "Nicht verknüpft",
+    cancelledBody:
+        "Es wurde nichts verknüpft. Sie können <strong>/link</strong> in Discord ausführen, falls Sie es sich anders überlegen.",
+};
+
+// Spanish. Register: informal "tú".
+const es: BotMessages = {
+    unknownInvoker: "No pude saber quién ejecutó ese comando.",
+    alreadyLinked: (name) => `Esta cuenta de Discord ya está vinculada a **${name}**. Ejecuta \`/unlink\` primero.`,
+    fallbackAccountName: "una cuenta de Tinyburg",
+    linkPrompt: [
+        "Inicia sesión en tinyburg.app para vincular tu cuenta. Este enlace funciona una sola vez y caduca en 10 minutos.",
+        "",
+        "Solo pide confirmar quién eres: tus torres siguen siendo privadas hasta que concedas ese acceso por separado.",
+    ].join("\n"),
+    linkButtonLabel: "Vincular mi cuenta de Tinyburg",
+    whoisSelfNotLinked: "No has vinculado una cuenta de Tinyburg. Ejecuta `/link` para conectar una.",
+    whoisOtherNotLinked: (mention) => `${mention} no ha vinculado una cuenta de Tinyburg.`,
+    whoisSelfLinked: (name) => `Has vinculado **${name}**.`,
+    whoisOtherLinked: (mention, name) => `${mention} ha vinculado **${name}**.`,
+    notLinked: "Esta cuenta de Discord no está vinculada a una cuenta de Tinyburg.",
+    unlinked: "Cuenta desvinculada. Tu cuenta de Tinyburg ya no responde a esta cuenta de Discord.",
+    linkedFollowUp: (name) => `Vinculada a **${name}**.`, // REVIEW: feminine agrees with "cuenta"
+    fallbackYourAccountName: "tu cuenta de Tinyburg",
+    linkedTitle: "Cuenta vinculada",
+    linkedBody: (name) =>
+        `Tu cuenta de Tinyburg <strong>${name}</strong> ya está vinculada a Discord. Puedes cerrar esta pestaña y volver.`,
+    failedTitle: "No se pudo vincular",
+    failedBody:
+        "Ese enlace no funcionó. Puede que haya caducado o que ya se haya usado. Ejecuta <strong>/link</strong> en Discord para empezar de nuevo.",
+    cancelledTitle: "Sin vincular",
+    cancelledBody: "No se vinculó nada. Puedes ejecutar <strong>/link</strong> en Discord si cambias de opinión.",
+};
+
+// French. Register: informal "tu".
+const fr: BotMessages = {
+    unknownInvoker: "Je n'ai pas pu déterminer qui a lancé cette commande.",
+    alreadyLinked: (name) => `Ce compte Discord est déjà lié à **${name}**. Lance d'abord \`/unlink\`.`,
+    fallbackAccountName: "un compte Tinyburg",
+    linkPrompt: [
+        "Connecte-toi sur tinyburg.app pour lier ton compte. Ce lien ne fonctionne qu'une seule fois et expire dans 10 minutes.",
+        "",
+        "Il sert uniquement à confirmer qui tu es : tes tours restent privées tant que tu n'accordes pas cet accès séparément.",
+    ].join("\n"),
+    linkButtonLabel: "Lier mon compte Tinyburg",
+    whoisSelfNotLinked: "Tu n'as pas lié de compte Tinyburg. Lance `/link` pour en connecter un.",
+    whoisOtherNotLinked: (mention) => `${mention} n'a pas lié de compte Tinyburg.`,
+    whoisSelfLinked: (name) => `Tu as lié **${name}**.`,
+    whoisOtherLinked: (mention, name) => `${mention} a lié **${name}**.`,
+    notLinked: "Ce compte Discord n'est lié à aucun compte Tinyburg.",
+    unlinked: "Compte délié. Ton compte Tinyburg ne répond plus à ce compte Discord.", // REVIEW: "délié" is a guess for "unlinked"; "dissocié" may read better
+    linkedFollowUp: (name) => `Lié à **${name}**.`,
+    fallbackYourAccountName: "ton compte Tinyburg",
+    linkedTitle: "Compte lié",
+    linkedBody: (name) =>
+        `Ton compte Tinyburg <strong>${name}</strong> est maintenant lié à Discord. Tu peux fermer cet onglet et revenir en arrière.`,
+    failedTitle: "Échec de la liaison", // REVIEW: guessed phrasing for "Could not link"
+    failedBody:
+        "Ce lien n'a pas fonctionné. Il a peut-être expiré ou déjà été utilisé. Lance <strong>/link</strong> dans Discord pour recommencer.",
+    cancelledTitle: "Non lié",
+    cancelledBody: "Rien n'a été lié. Tu peux lancer <strong>/link</strong> dans Discord si tu changes d'avis.",
+};
+
+export const botMessagesFor: Record<Language, BotMessages> = { de, en, es, fr };

--- a/apps/discord-bot/routes/oauth.ts
+++ b/apps/discord-bot/routes/oauth.ts
@@ -3,11 +3,13 @@ import { HttpClient, HttpRouter, HttpServerRequest, HttpServerResponse } from "e
 
 import type { Jwt } from "effect-oidc";
 
+import { type Language, fromAcceptLanguage } from "@tinyburg/ui/Internationalization";
 import { DiscordREST } from "dfx";
 import { Oidc } from "effect-oidc";
 
 import { sha256 } from "../crypto.ts";
 import { LinksRepository } from "../domain/links.ts";
+import { botMessagesFor } from "../messages.ts";
 import { tinyburgConfig } from "../tinyburg.ts";
 
 /**
@@ -24,12 +26,17 @@ import { tinyburgConfig } from "../tinyburg.ts";
  * so the URL is never posted where someone else can take it.
  */
 
-const page = (options: { readonly title: string; readonly body: string; readonly status: number }) =>
+const page = (options: {
+    readonly language: Language;
+    readonly title: string;
+    readonly body: string;
+    readonly status: number;
+}) =>
     HttpServerResponse.html(
         // Passed as a string rather than used as a template tag: the tagged
         // form returns an Effect, and nothing interpolated here is effectful.
         `<!doctype html>
-<html lang="en">
+<html lang="${options.language}">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
@@ -54,10 +61,11 @@ const page = (options: { readonly title: string; readonly body: string; readonly
 </html>`
     ).pipe(HttpServerResponse.setStatus(options.status));
 
-const linked = (name: string) =>
+const linked = (language: Language, name: string) =>
     page({
-        title: "Linked",
-        body: `Your Tinyburg account <strong>${name}</strong> is now linked to Discord. You can close this tab and go back.`,
+        language,
+        title: botMessagesFor[language].linkedTitle,
+        body: botMessagesFor[language].linkedBody(name),
         status: 200,
     });
 
@@ -68,18 +76,25 @@ const linked = (name: string) =>
  * provider refused - are all things an attacker probing callback URLs would
  * like to learn, and none of them are things the person in front of the page
  * can act on differently. The detail goes to the log instead.
+ *
+ * Functions of the language rather than module constants: a constant would
+ * bake the default language in at module load.
  */
-const failed = page({
-    title: "Could not link",
-    body: "That link did not work. It may have expired or already been used. Run <strong>/link</strong> in Discord to start again.",
-    status: 400,
-});
+const failed = (language: Language) =>
+    page({
+        language,
+        title: botMessagesFor[language].failedTitle,
+        body: botMessagesFor[language].failedBody,
+        status: 400,
+    });
 
-const cancelled = page({
-    title: "Not linked",
-    body: "Nothing was linked. You can run <strong>/link</strong> in Discord if you change your mind.",
-    status: 200,
-});
+const cancelled = (language: Language) =>
+    page({
+        language,
+        title: botMessagesFor[language].cancelledTitle,
+        body: botMessagesFor[language].cancelledBody,
+        status: 200,
+    });
 
 export const CallbackRoutesLive = Effect.gen(function* () {
     const tinyburg = yield* tinyburgConfig;
@@ -113,101 +128,113 @@ export const CallbackRoutesLive = Effect.gen(function* () {
             )
     );
 
-    const callback = Effect.gen(function* () {
-        const refuse = (reason: string) => Effect.as(Effect.logInfo(`link callback refused: ${reason}`), failed);
+    const handleCallback = (language: Language) =>
+        Effect.gen(function* () {
+            const messages = botMessagesFor[language];
+            const refuse = (reason: string) =>
+                Effect.as(Effect.logInfo(`link callback refused: ${reason}`), failed(language));
 
-        const maybeUrlParams = yield* HttpServerRequest.schemaSearchParams(
-            Schema.Union([
-                Schema.Struct({ error: Schema.String }),
-                Schema.Struct({ code: Schema.String, state: Schema.String }),
-            ])
-        ).pipe(Effect.option);
-        if (Option.isNone(maybeUrlParams)) {
-            return yield* refuse("malformed callback");
-        }
+            const maybeUrlParams = yield* HttpServerRequest.schemaSearchParams(
+                Schema.Union([
+                    Schema.Struct({ error: Schema.String }),
+                    Schema.Struct({ code: Schema.String, state: Schema.String }),
+                ])
+            ).pipe(Effect.option);
+            if (Option.isNone(maybeUrlParams)) {
+                return yield* refuse("malformed callback");
+            }
 
-        const urlParams = maybeUrlParams.value;
-        if ("error" in urlParams) {
-            return urlParams.error === "access_denied" ? cancelled : yield* refuse(urlParams.error);
-        }
+            const urlParams = maybeUrlParams.value;
+            if ("error" in urlParams) {
+                return urlParams.error === "access_denied" ? cancelled(language) : yield* refuse(urlParams.error);
+            }
 
-        // Claiming the pending link consumes it, so a replayed URL gets
-        // nothing even if the code were somehow still good.
-        const stateHash = yield* sha256(urlParams.state);
-        const maybePending = yield* LinksRepository.use((repo) => repo.claimPendingLink(stateHash)).pipe(
-            Effect.option,
-            Effect.map(Option.flatten)
-        );
-        if (Option.isNone(maybePending)) {
-            return yield* refuse("no pending link for this state");
-        }
-        const pending = maybePending.value;
-
-        const maybeToken = yield* Oidc.exchangeAuthorizationCode({
-            tokenEndpoint: `${tinyburg.issuer}/oauth/token`,
-            clientId: tinyburg.clientId,
-            clientSecret: Option.map(tinyburg.clientSecret, Redacted.value).pipe(Option.getOrUndefined),
-            redirectUri: tinyburg.redirectUri,
-            code: urlParams.code,
-            codeVerifier: pending.codeVerifier,
-        }).pipe(Effect.option);
-        if (Option.isNone(maybeToken)) {
-            return yield* refuse("token exchange failed");
-        }
-
-        // The id token is the only thing that says who authorized. The access
-        // token is deliberately dropped on the floor: this slice reads
-        // nothing from the trading api, so keeping it would be holding a
-        // capability with no use for it.
-        const maybeClaims = yield* cachedJwks.pipe(
-            Effect.flatMap((jwks) =>
-                Oidc.verifyIdToken({
-                    jwks,
-                    clientId: tinyburg.clientId,
-                    issuer: tinyburg.issuer,
-                    idToken: maybeToken.value.id_token ?? "",
-                })
-            ),
-            Effect.option
-        );
-        if (Option.isNone(maybeClaims)) {
-            return yield* refuse("id token did not verify");
-        }
-        const claims = maybeClaims.value;
-
-        const maybeLink = yield* LinksRepository.use((repo) =>
-            repo.upsertLink({
-                discordUserId: pending.discordUserId,
-                sub: claims.sub,
-                displayName: claims.name ?? null,
-                avatarUrl: claims.picture ?? null,
-            })
-        ).pipe(Effect.option);
-        if (Option.isNone(maybeLink)) {
-            return yield* refuse("could not store the link");
-        }
-
-        const name = Option.getOrElse(maybeLink.value.displayName, () => "your Tinyburg account");
-
-        // Best effort: rewrite the ephemeral reply so the confirmation shows
-        // up in Discord too, retiring the spent authorization button with it.
-        // The link is already made either way, so a failure here is worth a
-        // log and nothing more.
-        yield* rest
-            .updateOriginalWebhookMessage(applicationId, pending.interactionToken, {
-                payload: { content: `Linked to **${name}**.`, components: [] },
-            })
-            .pipe(
-                Effect.tapError((error) => Effect.logWarning("could not update the /link reply", error)),
-                Effect.ignore
+            // Claiming the pending link consumes it, so a replayed URL gets
+            // nothing even if the code were somehow still good.
+            const stateHash = yield* sha256(urlParams.state);
+            const maybePending = yield* LinksRepository.use((repo) => repo.claimPendingLink(stateHash)).pipe(
+                Effect.option,
+                Effect.map(Option.flatten)
             );
+            if (Option.isNone(maybePending)) {
+                return yield* refuse("no pending link for this state");
+            }
+            const pending = maybePending.value;
 
-        return linked(name);
-    }).pipe(
-        Effect.tapDefect((defect) => Effect.logError("link callback died", defect)),
-        Effect.catchDefect(() => Effect.succeed(failed)),
-        Effect.satisfiesErrorType<never>()
-    );
+            const maybeToken = yield* Oidc.exchangeAuthorizationCode({
+                tokenEndpoint: `${tinyburg.issuer}/oauth/token`,
+                clientId: tinyburg.clientId,
+                clientSecret: Option.map(tinyburg.clientSecret, Redacted.value).pipe(Option.getOrUndefined),
+                redirectUri: tinyburg.redirectUri,
+                code: urlParams.code,
+                codeVerifier: pending.codeVerifier,
+            }).pipe(Effect.option);
+            if (Option.isNone(maybeToken)) {
+                return yield* refuse("token exchange failed");
+            }
+
+            // The id token is the only thing that says who authorized. The access
+            // token is deliberately dropped on the floor: this slice reads
+            // nothing from the trading api, so keeping it would be holding a
+            // capability with no use for it.
+            const maybeClaims = yield* cachedJwks.pipe(
+                Effect.flatMap((jwks) =>
+                    Oidc.verifyIdToken({
+                        jwks,
+                        clientId: tinyburg.clientId,
+                        issuer: tinyburg.issuer,
+                        idToken: maybeToken.value.id_token ?? "",
+                    })
+                ),
+                Effect.option
+            );
+            if (Option.isNone(maybeClaims)) {
+                return yield* refuse("id token did not verify");
+            }
+            const claims = maybeClaims.value;
+
+            const maybeLink = yield* LinksRepository.use((repo) =>
+                repo.upsertLink({
+                    discordUserId: pending.discordUserId,
+                    sub: claims.sub,
+                    displayName: claims.name ?? null,
+                    avatarUrl: claims.picture ?? null,
+                })
+            ).pipe(Effect.option);
+            if (Option.isNone(maybeLink)) {
+                return yield* refuse("could not store the link");
+            }
+
+            const name = Option.getOrElse(maybeLink.value.displayName, () => messages.fallbackYourAccountName);
+
+            // Best effort: rewrite the ephemeral reply so the confirmation shows
+            // up in Discord too, retiring the spent authorization button with it.
+            // The link is already made either way, so a failure here is worth a
+            // log and nothing more. The Discord locale is not stored with the
+            // pending link, so the browser's language is the best proxy for the
+            // person who ran /link - they are the same person by construction.
+            yield* rest
+                .updateOriginalWebhookMessage(applicationId, pending.interactionToken, {
+                    payload: { content: messages.linkedFollowUp(name), components: [] },
+                })
+                .pipe(
+                    Effect.tapError((error) => Effect.logWarning("could not update the /link reply", error)),
+                    Effect.ignore
+                );
+
+            return linked(language, name);
+        }).pipe(
+            Effect.tapDefect((defect) => Effect.logError("link callback died", defect)),
+            Effect.catchDefect(() => Effect.succeed(failed(language)))
+        );
+
+    // A browser context, not a Discord one: the person may finish the round
+    // trip on a different device, so the page language is negotiated from
+    // Accept-Language rather than from the interaction's stored locale.
+    const callback = Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        return yield* handleCallback(fromAcceptLanguage(request.headers["accept-language"]));
+    }).pipe(Effect.satisfiesErrorType<never>());
 
     return HttpRouter.add("GET", "/discord/callback", callback);
 }).pipe(Layer.unwrap);


### PR DESCRIPTION
Stacked on #98. Bot replies in en/de/es/fr.

- New messages.ts: BotMessages interface, four locales
- interactions.ts resolves language from interaction.locale (guarded with an "in" check since ping interactions omit the field); slash-command names/descriptions stay English (name_localizations registration is separate and out of scope)
- routes/oauth.ts: page() emits html lang; module-level failed/cancelled constants became functions of language; the browser callback negotiates via Accept-Language
- whois replies split into four full-sentence variants so German/French word order works; English output unchanged
- 6 REVIEW comments mark translations needing human sign-off

