### PR TITLE
Automerge all Renovate updates except npm runtime and peer deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     "labels": ["dependencies", "renovate"],
     "ignorePaths": ["**/node_modules/**", "repos/effect/**", "repos/effect-smol/**"],
     "enabledManagers": ["github-actions", "nix", "git-submodules", "pip_requirements", "npm"],
+    "automerge": true,
     "automergeType": "branch",
     "git-submodules": {
         "enabled": true
@@ -27,7 +28,8 @@
         "enabled": true,
         "schedule": ["before 5am on monday"],
         "commitMessageAction": "Refresh",
-        "addLabels": ["lockfile-maintenance"]
+        "addLabels": ["lockfile-maintenance"],
+        "automerge": true
     },
     "packageRules": [
         {
@@ -105,10 +107,10 @@
             "addLabels": ["nix"]
         },
         {
-            "description": "Automerge minor and patch devDependency updates once CI passes on the update branch",
-            "matchDepTypes": ["devDependencies"],
-            "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-            "automerge": true
+            "description": "Never automerge npm runtime or peer dependency updates",
+            "matchManagers": ["npm"],
+            "matchDepTypes": ["dependencies", "peerDependencies"],
+            "automerge": false
         },
         {
             "description": "Never automerge typescript since minor releases can contain breaking changes",


### PR DESCRIPTION
Expands Renovate automerge so lockfile maintenance (Refresh) PRs, GitHub Actions, Nix, git submodules, and npm devDependencies all automerge once CI passes. npm runtime and peer dependency updates still require manual merge, and the typescript exception remains.

- Add top-level "automerge": true
- Enable automerge for lockFileMaintenance
- Replace the minor/patch devDependencies automerge rule with an opt-out rule for npm dependencies and peerDependencies